### PR TITLE
feat: Wordnik API와 ElasticSearch를 활용한 연동 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,50 +1,57 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.3.2'
-	id 'io.spring.dependency-management' version '1.1.6'
+    id 'java'
+    id 'org.springframework.boot' version '3.3.2'
+    id 'io.spring.dependency-management' version '1.1.6'
 }
 
 group = 'com.github.Hyun_jun_Lee0811'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
+    maven {
+        url "https://snapshots.elastic.co/maven/"
+    }
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.mariadb.jdbc:mariadb-java-client:3.3.3'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.mariadb.jdbc:mariadb-java-client:3.3.3'
 
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.h2database:h2'
-	annotationProcessor 'org.projectlombok:lombok'
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'com.h2database:h2'
+    annotationProcessor 'org.projectlombok:lombok'
 
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
-	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
-	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 
-	implementation 'co.elastic.clients:elasticsearch-java:8.14.3'
-	implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.0'
+    // Elasticsearch Java API Client
+    implementation 'co.elastic.clients:elasticsearch-java:8.13.4'
+    // Jackson Databind
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.0'
+    // Apache HttpComponents
+    implementation 'org.apache.httpcomponents:httpclient:4.5.13'
 }
 
 test {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,8 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.0'
     // Apache HttpComponents
     implementation 'org.apache.httpcomponents:httpclient:4.5.13'
+
+    implementation 'org.apache.commons:commons-collections4:4.4'
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,9 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+
+	implementation 'co.elastic.clients:elasticsearch-java:8.14.3'
+	implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.0'
 }
 
 test {

--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/client/WordnikClient.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/client/WordnikClient.java
@@ -12,6 +12,7 @@ import com.github.Hyun_jun_Lee0811.dictionary.model.dto.WordRelatedWordDto;
 import java.net.URI;
 import java.util.Collections;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.HttpClientErrorException;
@@ -21,16 +22,13 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
 @Component
+@RequiredArgsConstructor
 public class WordnikClient {
 
   @Value("${wordnik.api.key}")
   private String apiKey;
 
   private final RestTemplate restTemplate;
-
-  public WordnikClient(RestTemplate restTemplate) {
-    this.restTemplate = restTemplate;
-  }
 
   public List<WordDefinitionDto> getDefinitions(String word) {
     URI uri = UriComponentsBuilder.fromHttpUrl(

--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/client/WordnikClient.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/client/WordnikClient.java
@@ -1,0 +1,101 @@
+package com.github.Hyun_jun_Lee0811.dictionary.client;
+
+import static com.github.Hyun_jun_Lee0811.dictionary.type.ErrorCode.EXAMPLES_API_CLIENT_ERROR;
+import static com.github.Hyun_jun_Lee0811.dictionary.type.ErrorCode.EXAMPLES_API_NETWORK_ERROR;
+import static com.github.Hyun_jun_Lee0811.dictionary.type.ErrorCode.EXAMPLES_API_SERVER_ERROR;
+
+import com.github.Hyun_jun_Lee0811.dictionary.model.dto.WordDefinitionDto;
+import com.github.Hyun_jun_Lee0811.dictionary.model.dto.WordEtymologyDto;
+import com.github.Hyun_jun_Lee0811.dictionary.model.dto.WordExampleDto;
+import com.github.Hyun_jun_Lee0811.dictionary.model.dto.WordPronunciationDto;
+import com.github.Hyun_jun_Lee0811.dictionary.model.dto.WordRelatedWordDto;
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Component
+public class WordnikClient {
+
+  @Value("${wordnik.api.key}")
+  private String apiKey;
+
+  private final RestTemplate restTemplate;
+
+  public WordnikClient(RestTemplate restTemplate) {
+    this.restTemplate = restTemplate;
+  }
+
+  public List<WordDefinitionDto> getDefinitions(String word) {
+    URI uri = UriComponentsBuilder.fromHttpUrl(
+            "https://api.wordnik.com/v4/word.json/{word}/definitions")
+        .queryParam("api_key", apiKey)
+        .buildAndExpand(word)
+        .toUri();
+
+    WordDefinitionDto[] response = restTemplate.getForObject(uri, WordDefinitionDto[].class);
+    return response != null ? List.of(response) : Collections.emptyList();
+  }
+
+  public WordExampleDto getExamples(String word) {
+    URI uri = UriComponentsBuilder.fromHttpUrl(
+            "https://api.wordnik.com/v4/word.json/{word}/examples")
+        .queryParam("api_key", apiKey)
+        .buildAndExpand(word)
+        .toUri();
+    return getWordExampleDto(uri);
+  }
+
+  public List<WordRelatedWordDto> getRelatedWords(String word) {
+    URI uri = UriComponentsBuilder.fromHttpUrl(
+            "https://api.wordnik.com/v4/word.json/{word}/relatedWords")
+        .queryParam("api_key", apiKey)
+        .buildAndExpand(word)
+        .toUri();
+
+    WordRelatedWordDto[] response = restTemplate.getForObject(uri, WordRelatedWordDto[].class);
+    return response != null ? List.of(response) : Collections.emptyList();
+  }
+
+  public List<WordPronunciationDto> getPronunciations(String word) {
+    URI uri = UriComponentsBuilder.fromHttpUrl(
+            "https://api.wordnik.com/v4/word.json/{word}/pronunciations")
+        .queryParam("api_key", apiKey)
+        .buildAndExpand(word)
+        .toUri();
+
+    WordPronunciationDto[] response = restTemplate.getForObject(uri, WordPronunciationDto[].class);
+    return response != null ? List.of(response) : Collections.emptyList();
+  }
+
+  public List<WordEtymologyDto> getEtymologies(String word) {
+    URI uri = UriComponentsBuilder.fromHttpUrl(
+            "https://api.wordnik.com/v4/word.json/{word}/etymologies")
+        .queryParam("api_key", apiKey)
+        .buildAndExpand(word)
+        .toUri();
+
+    WordEtymologyDto[] response = restTemplate.getForObject(uri, WordEtymologyDto[].class);
+    return response != null ? List.of(response) : Collections.emptyList();
+  }
+
+  private WordExampleDto getWordExampleDto(URI uri) {
+    try {
+      return restTemplate.getForObject(uri, WordExampleDto.class);
+    } catch (HttpClientErrorException e) {
+      System.err.println(EXAMPLES_API_CLIENT_ERROR);
+    } catch (HttpServerErrorException e) {
+      System.err.println(EXAMPLES_API_SERVER_ERROR);
+    } catch (RestClientException e) {
+      System.err.println(EXAMPLES_API_NETWORK_ERROR);
+    }
+
+    return null;
+  }
+}

--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/client/WordnikClient.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/client/WordnikClient.java
@@ -13,6 +13,7 @@ import java.net.URI;
 import java.util.Collections;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.HttpClientErrorException;
@@ -22,6 +23,7 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
 @Component
+@Slf4j
 @RequiredArgsConstructor
 public class WordnikClient {
 
@@ -31,69 +33,51 @@ public class WordnikClient {
   private final RestTemplate restTemplate;
 
   public List<WordDefinitionDto> getDefinitions(String word) {
-    URI uri = UriComponentsBuilder.fromHttpUrl(
-            "https://api.wordnik.com/v4/word.json/{word}/definitions")
-        .queryParam("api_key", apiKey)
-        .buildAndExpand(word)
-        .toUri();
-
-    WordDefinitionDto[] response = restTemplate.getForObject(uri, WordDefinitionDto[].class);
+    URI uri = buildUri("https://api.wordnik.com/v4/word.json/{word}/definitions", word);
+    WordDefinitionDto[] response = executeRequest(uri, WordDefinitionDto[].class);
     return response != null ? List.of(response) : Collections.emptyList();
   }
 
   public WordExampleDto getExamples(String word) {
-    URI uri = UriComponentsBuilder.fromHttpUrl(
-            "https://api.wordnik.com/v4/word.json/{word}/examples")
-        .queryParam("api_key", apiKey)
-        .buildAndExpand(word)
-        .toUri();
-    return getWordExampleDto(uri);
+    URI uri = buildUri("https://api.wordnik.com/v4/word.json/{word}/examples", word);
+    return executeRequest(uri, WordExampleDto.class);
   }
 
   public List<WordRelatedWordDto> getRelatedWords(String word) {
-    URI uri = UriComponentsBuilder.fromHttpUrl(
-            "https://api.wordnik.com/v4/word.json/{word}/relatedWords")
-        .queryParam("api_key", apiKey)
-        .buildAndExpand(word)
-        .toUri();
-
-    WordRelatedWordDto[] response = restTemplate.getForObject(uri, WordRelatedWordDto[].class);
+    URI uri = buildUri("https://api.wordnik.com/v4/word.json/{word}/relatedWords", word);
+    WordRelatedWordDto[] response = executeRequest(uri, WordRelatedWordDto[].class);
     return response != null ? List.of(response) : Collections.emptyList();
   }
 
   public List<WordPronunciationDto> getPronunciations(String word) {
-    URI uri = UriComponentsBuilder.fromHttpUrl(
-            "https://api.wordnik.com/v4/word.json/{word}/pronunciations")
-        .queryParam("api_key", apiKey)
-        .buildAndExpand(word)
-        .toUri();
-
-    WordPronunciationDto[] response = restTemplate.getForObject(uri, WordPronunciationDto[].class);
+    URI uri = buildUri("https://api.wordnik.com/v4/word.json/{word}/pronunciations", word);
+    WordPronunciationDto[] response = executeRequest(uri, WordPronunciationDto[].class);
     return response != null ? List.of(response) : Collections.emptyList();
   }
 
   public List<WordEtymologyDto> getEtymologies(String word) {
-    URI uri = UriComponentsBuilder.fromHttpUrl(
-            "https://api.wordnik.com/v4/word.json/{word}/etymologies")
-        .queryParam("api_key", apiKey)
-        .buildAndExpand(word)
-        .toUri();
-
-    WordEtymologyDto[] response = restTemplate.getForObject(uri, WordEtymologyDto[].class);
+    URI uri = buildUri("https://api.wordnik.com/v4/word.json/{word}/etymologies", word);
+    WordEtymologyDto[] response = executeRequest(uri, WordEtymologyDto[].class);
     return response != null ? List.of(response) : Collections.emptyList();
   }
 
-  private WordExampleDto getWordExampleDto(URI uri) {
-    try {
-      return restTemplate.getForObject(uri, WordExampleDto.class);
-    } catch (HttpClientErrorException e) {
-      System.err.println(EXAMPLES_API_CLIENT_ERROR);
-    } catch (HttpServerErrorException e) {
-      System.err.println(EXAMPLES_API_SERVER_ERROR);
-    } catch (RestClientException e) {
-      System.err.println(EXAMPLES_API_NETWORK_ERROR);
-    }
+  private URI buildUri(String urlTemplate, String word) {
+    return UriComponentsBuilder.fromHttpUrl(urlTemplate)
+        .queryParam("api_key", apiKey)
+        .buildAndExpand(word)
+        .toUri();
+  }
 
+  private <T> T executeRequest(URI uri, Class<T> responseType) {
+    try {
+      return restTemplate.getForObject(uri, responseType);
+    } catch (HttpClientErrorException e) {
+      log.error(String.valueOf(EXAMPLES_API_CLIENT_ERROR));
+    } catch (HttpServerErrorException e) {
+      log.error(String.valueOf(EXAMPLES_API_SERVER_ERROR));
+    } catch (RestClientException e) {
+      log.error(String.valueOf(EXAMPLES_API_NETWORK_ERROR));
+    }
     return null;
   }
 }

--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/config/AppConfig.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/config/AppConfig.java
@@ -1,5 +1,7 @@
 package com.github.Hyun_jun_Lee0811.dictionary.config;
 
+import org.apache.commons.collections4.Trie;
+import org.apache.commons.collections4.trie.PatriciaTrie;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -11,5 +13,10 @@ public class AppConfig {
   @Bean
   public PasswordEncoder passwordEncoder() {
     return new BCryptPasswordEncoder();
+  }
+
+  @Bean
+  public Trie<String, Boolean> trie() {
+    return new PatriciaTrie<>();
   }
 }

--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/config/ElasticSearchConfig.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/config/ElasticSearchConfig.java
@@ -1,0 +1,27 @@
+package com.github.Hyun_jun_Lee0811.dictionary.config;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestClientBuilder;
+import org.apache.http.HttpHost;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ElasticSearchConfig {
+
+  @Value("${aws.elasticsearch.url}")
+  private String url;
+
+  @Bean
+  public ElasticsearchClient elasticsearchClient() {
+    RestClientBuilder builder = RestClient.builder(HttpHost.create(url));
+    RestClient Client = builder.build();
+    RestClientTransport transport = new RestClientTransport(Client, new JacksonJsonpMapper());
+
+    return new ElasticsearchClient(transport);
+  }
+}

--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/config/ElasticSearchConfig.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/config/ElasticSearchConfig.java
@@ -3,6 +3,9 @@ package com.github.Hyun_jun_Lee0811.dictionary.config;
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.transport.rest_client.RestClientTransport;
 import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
 import org.apache.http.HttpHost;
@@ -16,11 +19,25 @@ public class ElasticSearchConfig {
   @Value("${aws.elasticsearch.url}")
   private String url;
 
+  @Value("${aws.elasticsearch.username}")
+  private String username;
+
+  @Value("${aws.elasticsearch.password}")
+  private String password;
+
   @Bean
   public ElasticsearchClient elasticsearchClient() {
-    RestClientBuilder builder = RestClient.builder(HttpHost.create(url));
-    RestClient Client = builder.build();
-    RestClientTransport transport = new RestClientTransport(Client, new JacksonJsonpMapper());
+    BasicCredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+    credentialsProvider.setCredentials(
+        AuthScope.ANY,
+        new UsernamePasswordCredentials(username, password));
+
+    RestClientBuilder builder = RestClient.builder(HttpHost.create(url))
+        .setHttpClientConfigCallback(httpClientBuilder ->
+            httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider));
+
+    RestClient client = builder.build();
+    RestClientTransport transport = new RestClientTransport(client, new JacksonJsonpMapper());
 
     return new ElasticsearchClient(transport);
   }

--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/config/RestTemplateConfig.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/config/RestTemplateConfig.java
@@ -1,0 +1,14 @@
+package com.github.Hyun_jun_Lee0811.dictionary.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+  @Bean
+  public RestTemplate restTemplate() {
+    return new RestTemplate();
+  }
+}

--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/controller/WordController.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/controller/WordController.java
@@ -4,42 +4,50 @@ import com.github.Hyun_jun_Lee0811.dictionary.model.dto.*;
 import com.github.Hyun_jun_Lee0811.dictionary.service.WordService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
 @RestController
-@RequestMapping("/word.json/{word}")
+@RequestMapping("/word.json")
 @RequiredArgsConstructor
 public class WordController {
 
   private final WordService wordService;
 
-  @GetMapping("/definitions")
+  @GetMapping("/{word}/definitions")
   public List<WordDefinitionDto> getDefinitions(@Valid @PathVariable("word") String word) {
     return wordService.getDefinitions(word);
   }
 
-  @GetMapping("/examples")
+  @GetMapping("/{word}/examples")
   public WordExampleDto getExamples(@Valid @PathVariable("word") String word) {
     return wordService.getExamples(word);
   }
 
-  @GetMapping("/relatedWords")
+  @GetMapping("/{word}/relatedWords")
   public List<WordRelatedWordDto> getRelatedWords(@Valid @PathVariable("word") String word) {
     return wordService.getRelatedWords(word);
   }
 
-  @GetMapping("/pronunciations")
+  @GetMapping("/{word}/pronunciations")
   public List<WordPronunciationDto> getPronunciations(@Valid @PathVariable("word") String word) {
     return wordService.getPronunciations(word);
   }
 
-  @GetMapping("/etymologies")
+  @GetMapping("/{word}/etymologies")
   public List<WordEtymologyDto> getEtymologies(@Valid @PathVariable("word") String word) {
     return wordService.getEtymologies(word);
+  }
+
+  @GetMapping("/autocomplete")
+  public ResponseEntity<List<String>> autocomplete(@Valid @RequestParam("word") String word) {
+    List<String> suggestions = wordService.autocomplete(word);
+    return ResponseEntity.ok(suggestions);
   }
 }

--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/controller/WordController.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/controller/WordController.java
@@ -1,0 +1,45 @@
+package com.github.Hyun_jun_Lee0811.dictionary.controller;
+
+import com.github.Hyun_jun_Lee0811.dictionary.model.dto.*;
+import com.github.Hyun_jun_Lee0811.dictionary.service.WordService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/word.json/{word}")
+@RequiredArgsConstructor
+public class WordController {
+
+  private final WordService wordService;
+
+  @GetMapping("/definitions")
+  public List<WordDefinitionDto> getDefinitions(@Valid @PathVariable("word") String word) {
+    return wordService.getDefinitions(word);
+  }
+
+  @GetMapping("/examples")
+  public WordExampleDto getExamples(@Valid @PathVariable("word") String word) {
+    return wordService.getExamples(word);
+  }
+
+  @GetMapping("/relatedWords")
+  public List<WordRelatedWordDto> getRelatedWords(@Valid @PathVariable("word") String word) {
+    return wordService.getRelatedWords(word);
+  }
+
+  @GetMapping("/pronunciations")
+  public List<WordPronunciationDto> getPronunciations(@Valid @PathVariable("word") String word) {
+    return wordService.getPronunciations(word);
+  }
+
+  @GetMapping("/etymologies")
+  public List<WordEtymologyDto> getEtymologies(@Valid @PathVariable("word") String word) {
+    return wordService.getEtymologies(word);
+  }
+}

--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/controller/WordController.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/controller/WordController.java
@@ -14,33 +14,33 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 @RestController
-@RequestMapping("/word.json")
+@RequestMapping("/dictionary")
 @RequiredArgsConstructor
 public class WordController {
 
   private final WordService wordService;
 
-  @GetMapping("/{word}/definitions")
+  @GetMapping("/definitions/{word}")
   public List<WordDefinitionDto> getDefinitions(@Valid @PathVariable("word") String word) {
     return wordService.getDefinitions(word);
   }
 
-  @GetMapping("/{word}/examples")
+  @GetMapping("/examples/{word}")
   public WordExampleDto getExamples(@Valid @PathVariable("word") String word) {
     return wordService.getExamples(word);
   }
 
-  @GetMapping("/{word}/relatedWords")
+  @GetMapping("/related-words/{word}")
   public List<WordRelatedWordDto> getRelatedWords(@Valid @PathVariable("word") String word) {
     return wordService.getRelatedWords(word);
   }
 
-  @GetMapping("/{word}/pronunciations")
+  @GetMapping("/pronunciations/{word}")
   public List<WordPronunciationDto> getPronunciations(@Valid @PathVariable("word") String word) {
     return wordService.getPronunciations(word);
   }
 
-  @GetMapping("/{word}/etymologies")
+  @GetMapping("/etymologies/{word}")
   public List<WordEtymologyDto> getEtymologies(@Valid @PathVariable("word") String word) {
     return wordService.getEtymologies(word);
   }

--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/model/dto/WordDefinitionDto.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/model/dto/WordDefinitionDto.java
@@ -1,0 +1,68 @@
+package com.github.Hyun_jun_Lee0811.dictionary.model.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class WordDefinitionDto {
+
+  @JsonProperty("id")
+  private String id;
+
+  @JsonProperty("word")
+  private String word;
+
+  @JsonProperty("attributionText")
+  private String attributionText;
+
+  @JsonProperty("attributionUrl")
+  private String attributionUrl;
+
+  @JsonProperty("citations")
+  private List<Map<String, Object>> citations;
+
+  @JsonProperty("exampleUses")
+  private List<Map<String, Object>> exampleUses;
+
+  @JsonProperty("extendedText")
+  private String extendedText;
+
+  @JsonProperty("labels")
+  private List<Map<String, Object>> labels;
+
+  @JsonProperty("notes")
+  private List<Map<String, Object>> notes;
+
+  @JsonProperty("partOfSpeech")
+  private String partOfSpeech;
+
+  @JsonProperty("relatedWords")
+  private List<Map<String, Object>> relatedWords;
+
+  @JsonProperty("score")
+  private int score;
+
+  @JsonProperty("seqString")
+  private String seqString;
+
+  @JsonProperty("sequence")
+  private String sequence;
+
+  @JsonProperty("sourceDictionary")
+  private String sourceDictionary;
+
+  @JsonProperty("text")
+  private String text;
+
+  @JsonProperty("textProns")
+  private List<Map<String, Object>> textProns;
+
+}

--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/model/dto/WordDefinitionDto.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/model/dto/WordDefinitionDto.java
@@ -1,6 +1,5 @@
 package com.github.Hyun_jun_Lee0811.dictionary.model.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 import java.util.Map;
 import lombok.AllArgsConstructor;
@@ -14,55 +13,22 @@ import lombok.Setter;
 @NoArgsConstructor
 public class WordDefinitionDto {
 
-  @JsonProperty("id")
   private String id;
-
-  @JsonProperty("word")
   private String word;
-
-  @JsonProperty("attributionText")
   private String attributionText;
-
-  @JsonProperty("attributionUrl")
   private String attributionUrl;
-
-  @JsonProperty("citations")
   private List<Map<String, Object>> citations;
-
-  @JsonProperty("exampleUses")
   private List<Map<String, Object>> exampleUses;
-
-  @JsonProperty("extendedText")
   private String extendedText;
-
-  @JsonProperty("labels")
   private List<Map<String, Object>> labels;
-
-  @JsonProperty("notes")
   private List<Map<String, Object>> notes;
-
-  @JsonProperty("partOfSpeech")
   private String partOfSpeech;
-
-  @JsonProperty("relatedWords")
   private List<Map<String, Object>> relatedWords;
-
-  @JsonProperty("score")
   private int score;
-
-  @JsonProperty("seqString")
   private String seqString;
-
-  @JsonProperty("sequence")
   private String sequence;
-
-  @JsonProperty("sourceDictionary")
   private String sourceDictionary;
-
-  @JsonProperty("text")
   private String text;
-
-  @JsonProperty("textProns")
   private List<Map<String, Object>> textProns;
 
 }

--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/model/dto/WordEtymologyDto.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/model/dto/WordEtymologyDto.java
@@ -1,6 +1,5 @@
 package com.github.Hyun_jun_Lee0811.dictionary.model.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,6 +11,5 @@ import lombok.Setter;
 @NoArgsConstructor
 public class WordEtymologyDto {
 
-  @JsonProperty("etymologies")
   private String word;
 }

--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/model/dto/WordEtymologyDto.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/model/dto/WordEtymologyDto.java
@@ -1,0 +1,17 @@
+package com.github.Hyun_jun_Lee0811.dictionary.model.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class WordEtymologyDto {
+
+  @JsonProperty("etymologies")
+  private String word;
+}

--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/model/dto/WordExampleDto.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/model/dto/WordExampleDto.java
@@ -18,7 +18,9 @@ public class WordExampleDto {
 
   @Getter
   @Setter
-  private static class ExampleDto {
+  @AllArgsConstructor
+  @NoArgsConstructor
+  public static class ExampleDto {
 
     @JsonProperty("provider")
     private ProviderDto provider;
@@ -53,7 +55,9 @@ public class WordExampleDto {
 
   @Getter
   @Setter
-  private static class ProviderDto {
+  @AllArgsConstructor
+  @NoArgsConstructor
+  public static class ProviderDto {
 
     @JsonProperty("id")
     private Integer id;

--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/model/dto/WordExampleDto.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/model/dto/WordExampleDto.java
@@ -1,0 +1,61 @@
+package com.github.Hyun_jun_Lee0811.dictionary.model.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class WordExampleDto {
+
+  @JsonProperty("examples")
+  private List<ExampleDto> examples;
+
+  @Getter
+  @Setter
+  private static class ExampleDto {
+
+    @JsonProperty("provider")
+    private ProviderDto provider;
+
+    @JsonProperty("year")
+    private Integer year;
+
+    @JsonProperty("rating")
+    private Integer rating;
+
+    @JsonProperty("url")
+    private String url;
+
+    @JsonProperty("word")
+    private String word;
+
+    @JsonProperty("text")
+    private String text;
+
+    @JsonProperty("documentId")
+    private Integer documentId;
+
+    @JsonProperty("exampleId")
+    private Integer exampleId;
+
+    @JsonProperty("title")
+    private String title;
+
+    @JsonProperty("author")
+    private String author;
+  }
+
+  @Getter
+  @Setter
+  private static class ProviderDto {
+
+    @JsonProperty("id")
+    private Integer id;
+  }
+}

--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/model/dto/WordExampleDto.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/model/dto/WordExampleDto.java
@@ -1,6 +1,5 @@
 package com.github.Hyun_jun_Lee0811.dictionary.model.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -13,7 +12,6 @@ import lombok.Setter;
 @NoArgsConstructor
 public class WordExampleDto {
 
-  @JsonProperty("examples")
   private List<ExampleDto> examples;
 
   @Getter
@@ -22,34 +20,15 @@ public class WordExampleDto {
   @NoArgsConstructor
   public static class ExampleDto {
 
-    @JsonProperty("provider")
     private ProviderDto provider;
-
-    @JsonProperty("year")
     private Integer year;
-
-    @JsonProperty("rating")
     private Integer rating;
-
-    @JsonProperty("url")
     private String url;
-
-    @JsonProperty("word")
     private String word;
-
-    @JsonProperty("text")
     private String text;
-
-    @JsonProperty("documentId")
     private Integer documentId;
-
-    @JsonProperty("exampleId")
     private Integer exampleId;
-
-    @JsonProperty("title")
     private String title;
-
-    @JsonProperty("author")
     private String author;
   }
 
@@ -59,7 +38,6 @@ public class WordExampleDto {
   @NoArgsConstructor
   public static class ProviderDto {
 
-    @JsonProperty("id")
     private Integer id;
   }
 }

--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/model/dto/WordPronunciationDto.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/model/dto/WordPronunciationDto.java
@@ -1,6 +1,5 @@
 package com.github.Hyun_jun_Lee0811.dictionary.model.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,21 +11,10 @@ import lombok.Setter;
 @NoArgsConstructor
 public class WordPronunciationDto {
 
-  @JsonProperty("seq")
   private int seq;
-
-  @JsonProperty("raw")
   private String raw;
-
-  @JsonProperty("rawType")
   private String rawType;
-
-  @JsonProperty("id")
   private String id;
-
-  @JsonProperty("attributionText")
   private String attributionText;
-
-  @JsonProperty("attributionUrl")
   private String attributionUrl;
 }

--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/model/dto/WordPronunciationDto.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/model/dto/WordPronunciationDto.java
@@ -1,0 +1,32 @@
+package com.github.Hyun_jun_Lee0811.dictionary.model.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class WordPronunciationDto {
+
+  @JsonProperty("seq")
+  private int seq;
+
+  @JsonProperty("raw")
+  private String raw;
+
+  @JsonProperty("rawType")
+  private String rawType;
+
+  @JsonProperty("id")
+  private String id;
+
+  @JsonProperty("attributionText")
+  private String attributionText;
+
+  @JsonProperty("attributionUrl")
+  private String attributionUrl;
+}

--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/model/dto/WordRelatedWordDto.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/model/dto/WordRelatedWordDto.java
@@ -1,0 +1,21 @@
+package com.github.Hyun_jun_Lee0811.dictionary.model.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class WordRelatedWordDto {
+
+  @JsonProperty("relationshipType")
+  private String relationshipType;
+
+  @JsonProperty("words")
+  private List<String> words;
+}

--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/model/dto/WordRelatedWordDto.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/model/dto/WordRelatedWordDto.java
@@ -1,6 +1,5 @@
 package com.github.Hyun_jun_Lee0811.dictionary.model.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -13,9 +12,6 @@ import lombok.Setter;
 @NoArgsConstructor
 public class WordRelatedWordDto {
 
-  @JsonProperty("relationshipType")
   private String relationshipType;
-
-  @JsonProperty("words")
   private List<String> words;
 }

--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/service/WordService.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/service/WordService.java
@@ -16,32 +16,36 @@ public class WordService {
   private final Trie<String, Boolean> trie;
 
   public List<WordDefinitionDto> getDefinitions(String word) {
-    List<WordDefinitionDto> definitions = wordnikClient.getDefinitions(normalizeWord(word));
+    String normalizedWord = normalizeWord(word);
+    List<WordDefinitionDto> definitions = wordnikClient.getDefinitions(normalizedWord);
     updateTrie(normalizeWord(word));
     return definitions;
   }
 
   public WordExampleDto getExamples(String word) {
-    WordExampleDto examples = wordnikClient.getExamples(normalizeWord(word));
+    String normalizedWord = normalizeWord(word);
+    WordExampleDto examples = wordnikClient.getExamples(normalizedWord);
     updateTrie(normalizeWord(word));
     return examples;
   }
 
   public List<WordRelatedWordDto> getRelatedWords(String word) {
-    List<WordRelatedWordDto> relatedWords = wordnikClient.getRelatedWords(normalizeWord(word));
-    updateTrie(normalizeWord(word));
+    String normalizedWord = normalizeWord(word);
+    List<WordRelatedWordDto> relatedWords = wordnikClient.getRelatedWords(normalizedWord);
+    updateTrie(normalizedWord);
     return relatedWords;
   }
 
   public List<WordPronunciationDto> getPronunciations(String word) {
-    List<WordPronunciationDto> pronunciations = wordnikClient.getPronunciations(
-        normalizeWord(word));
+    String normalizedWord = normalizeWord(word);
+    List<WordPronunciationDto> pronunciations = wordnikClient.getPronunciations(normalizedWord);
     updateTrie(normalizeWord(word));
     return pronunciations;
   }
 
   public List<WordEtymologyDto> getEtymologies(String word) {
-    List<WordEtymologyDto> etymologies = wordnikClient.getEtymologies(normalizeWord(word));
+    String normalizedWord = normalizeWord(word);
+    List<WordEtymologyDto> etymologies = wordnikClient.getEtymologies(normalizedWord);
     updateTrie(normalizeWord(word));
     return etymologies;
   }

--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/service/WordService.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/service/WordService.java
@@ -3,6 +3,7 @@ package com.github.Hyun_jun_Lee0811.dictionary.service;
 import com.github.Hyun_jun_Lee0811.dictionary.client.WordnikClient;
 import com.github.Hyun_jun_Lee0811.dictionary.model.dto.*;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.collections4.Trie;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -12,24 +13,45 @@ import java.util.List;
 public class WordService {
 
   private final WordnikClient wordnikClient;
+  private final Trie<String, Boolean> trie;
 
   public List<WordDefinitionDto> getDefinitions(String word) {
-    return wordnikClient.getDefinitions(word);
+    List<WordDefinitionDto> definitions = wordnikClient.getDefinitions(word);
+    updateTrieWithWord(word);
+    return definitions;
   }
 
   public WordExampleDto getExamples(String word) {
-    return wordnikClient.getExamples(word);
+    WordExampleDto examples = wordnikClient.getExamples(word);
+    updateTrieWithWord(word);
+    return examples;
   }
 
   public List<WordRelatedWordDto> getRelatedWords(String word) {
-    return wordnikClient.getRelatedWords(word);
+    List<WordRelatedWordDto> relatedWords = wordnikClient.getRelatedWords(word);
+    updateTrieWithWord(word);
+    return relatedWords;
   }
 
   public List<WordPronunciationDto> getPronunciations(String word) {
-    return wordnikClient.getPronunciations(word);
+    List<WordPronunciationDto> pronunciations = wordnikClient.getPronunciations(word);
+    updateTrieWithWord(word);
+    return pronunciations;
   }
 
   public List<WordEtymologyDto> getEtymologies(String word) {
-    return wordnikClient.getEtymologies(word);
+    List<WordEtymologyDto> etymologies = wordnikClient.getEtymologies(word);
+    updateTrieWithWord(word);
+    return etymologies;
+  }
+
+  public List<String> autocomplete(String prefix) {
+    return trie.prefixMap(prefix).keySet()
+        .stream()
+        .toList();
+  }
+
+  private void updateTrieWithWord(String word) {
+    trie.put(word, Boolean.TRUE);
   }
 }

--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/service/WordService.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/service/WordService.java
@@ -16,42 +16,47 @@ public class WordService {
   private final Trie<String, Boolean> trie;
 
   public List<WordDefinitionDto> getDefinitions(String word) {
-    List<WordDefinitionDto> definitions = wordnikClient.getDefinitions(word);
-    updateTrieWithWord(word);
+    List<WordDefinitionDto> definitions = wordnikClient.getDefinitions(normalizeWord(word));
+    updateTrie(normalizeWord(word));
     return definitions;
   }
 
   public WordExampleDto getExamples(String word) {
-    WordExampleDto examples = wordnikClient.getExamples(word);
-    updateTrieWithWord(word);
+    WordExampleDto examples = wordnikClient.getExamples(normalizeWord(word));
+    updateTrie(normalizeWord(word));
     return examples;
   }
 
   public List<WordRelatedWordDto> getRelatedWords(String word) {
-    List<WordRelatedWordDto> relatedWords = wordnikClient.getRelatedWords(word);
-    updateTrieWithWord(word);
+    List<WordRelatedWordDto> relatedWords = wordnikClient.getRelatedWords(normalizeWord(word));
+    updateTrie(normalizeWord(word));
     return relatedWords;
   }
 
   public List<WordPronunciationDto> getPronunciations(String word) {
-    List<WordPronunciationDto> pronunciations = wordnikClient.getPronunciations(word);
-    updateTrieWithWord(word);
+    List<WordPronunciationDto> pronunciations = wordnikClient.getPronunciations(
+        normalizeWord(word));
+    updateTrie(normalizeWord(word));
     return pronunciations;
   }
 
   public List<WordEtymologyDto> getEtymologies(String word) {
-    List<WordEtymologyDto> etymologies = wordnikClient.getEtymologies(word);
-    updateTrieWithWord(word);
+    List<WordEtymologyDto> etymologies = wordnikClient.getEtymologies(normalizeWord(word));
+    updateTrie(normalizeWord(word));
     return etymologies;
   }
 
-  public List<String> autocomplete(String prefix) {
-    return trie.prefixMap(prefix).keySet()
+  public List<String> autocomplete(String word) {
+    return trie.prefixMap(normalizeWord(word)).keySet()
         .stream()
         .toList();
   }
 
-  private void updateTrieWithWord(String word) {
+  private void updateTrie(String word) {
     trie.put(word, Boolean.TRUE);
+  }
+
+  private String normalizeWord(String word) {
+    return word.toLowerCase();
   }
 }

--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/service/WordService.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/service/WordService.java
@@ -1,0 +1,35 @@
+package com.github.Hyun_jun_Lee0811.dictionary.service;
+
+import com.github.Hyun_jun_Lee0811.dictionary.client.WordnikClient;
+import com.github.Hyun_jun_Lee0811.dictionary.model.dto.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class WordService {
+
+  private final WordnikClient wordnikClient;
+
+  public List<WordDefinitionDto> getDefinitions(String word) {
+    return wordnikClient.getDefinitions(word);
+  }
+
+  public WordExampleDto getExamples(String word) {
+    return wordnikClient.getExamples(word);
+  }
+
+  public List<WordRelatedWordDto> getRelatedWords(String word) {
+    return wordnikClient.getRelatedWords(word);
+  }
+
+  public List<WordPronunciationDto> getPronunciations(String word) {
+    return wordnikClient.getPronunciations(word);
+  }
+
+  public List<WordEtymologyDto> getEtymologies(String word) {
+    return wordnikClient.getEtymologies(word);
+  }
+}

--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/type/ErrorCode.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/type/ErrorCode.java
@@ -14,7 +14,10 @@ public enum ErrorCode {
   INVALID_JWT_SIGNATURE("잘못된 JWT 서명입니다."),
   EXPIRED_JWT_TOKEN("만료된 JWT 토큰입니다."),
   UNSUPPORTED_JWT_TOKEN("지원되지 않는 JWT 토큰입니다."),
-  INVALID_JWT_TOKEN("JWT 토큰이 잘못되었습니다.");
+  INVALID_JWT_TOKEN("JWT 토큰이 잘못되었습니다."),
+  EXAMPLES_API_CLIENT_ERROR("API 호출 중 클라이언트 오류가 발생했습니다."),
+  EXAMPLES_API_SERVER_ERROR("API 호출 중 서버 오류가 발생했습니다."),
+  EXAMPLES_API_NETWORK_ERROR("API 호출 중 네트워크 오류가 발생했습니다.");
 
   private final String message;
 }

--- a/src/test/java/com/github/Hyun_jun_Lee0811/dictionary/DictionaryApplicationTests.java
+++ b/src/test/java/com/github/Hyun_jun_Lee0811/dictionary/DictionaryApplicationTests.java
@@ -1,19 +1,7 @@
 package com.github.Hyun_jun_Lee0811.dictionary;
 
-import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
 class DictionaryApplicationTests {
-
-	@Test
-	void success_SignUp() {
-	}
-
-	@Test
-	void fail_SignUp() {
-	}
-
-
-
 }

--- a/src/test/java/com/github/Hyun_jun_Lee0811/dictionary/ElasticSearchConfigTest.java
+++ b/src/test/java/com/github/Hyun_jun_Lee0811/dictionary/ElasticSearchConfigTest.java
@@ -1,0 +1,22 @@
+package com.github.Hyun_jun_Lee0811.dictionary;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@SpringBootTest
+class ElasticSearchConfigTest {
+
+  @Autowired
+  private ElasticsearchClient elasticsearchClient;
+
+  @Test
+  @DisplayName("Elasticsearch 클라이언트 구성 검증")
+  void contextLoads() {
+    assertNotNull(elasticsearchClient, "Elasticsearch 클라이언트가 구성되어 있으며 null이 아닙니다.");
+  }
+}

--- a/src/test/java/com/github/Hyun_jun_Lee0811/dictionary/config/ElasticSearchConfigTest.java
+++ b/src/test/java/com/github/Hyun_jun_Lee0811/dictionary/config/ElasticSearchConfigTest.java
@@ -1,4 +1,4 @@
-package com.github.Hyun_jun_Lee0811.dictionary;
+package com.github.Hyun_jun_Lee0811.dictionary.config;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/com/github/Hyun_jun_Lee0811/dictionary/config/ElasticSearchConfigTest.java
+++ b/src/test/java/com/github/Hyun_jun_Lee0811/dictionary/config/ElasticSearchConfigTest.java
@@ -1,6 +1,7 @@
 package com.github.Hyun_jun_Lee0811.dictionary.config;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.cluster.HealthResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,4 +20,17 @@ class ElasticSearchConfigTest {
   void contextLoads() {
     assertNotNull(elasticsearchClient, "Elasticsearch 클라이언트가 구성되어 있으며 null이 아닙니다.");
   }
+
+  @Test
+  @DisplayName("Elasticsearch 클러스터와의 연결")
+  public void testClusterHealth() {
+    try {
+      HealthResponse healthResponse = elasticsearchClient.cluster().health();
+      System.out.println(healthResponse);
+    } catch (Exception e) {
+      System.err.println("Elasticsearch 클러스터와의 연결 실패");
+      e.printStackTrace();
+    }
+  }
+
 }

--- a/src/test/java/com/github/Hyun_jun_Lee0811/dictionary/controller/WordControllerTest.java
+++ b/src/test/java/com/github/Hyun_jun_Lee0811/dictionary/controller/WordControllerTest.java
@@ -1,0 +1,224 @@
+package com.github.Hyun_jun_Lee0811.dictionary.controller;
+
+import com.github.Hyun_jun_Lee0811.dictionary.model.dto.*;
+import com.github.Hyun_jun_Lee0811.dictionary.service.WordService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Collections;
+import java.util.List;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+public class WordControllerTest {
+
+  private MockMvc mockMvc;
+
+  @Mock
+  private WordService wordService;
+
+  @InjectMocks
+  private WordController wordController;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+    this.mockMvc = MockMvcBuilders.standaloneSetup(wordController).build();
+  }
+
+  @Test
+  @DisplayName("단어 정의 조회 성공")
+  void getDefinitions_Success() throws Exception {
+    String word = "test";
+    List<WordDefinitionDto> definitions = Collections.singletonList(
+        new WordDefinitionDto(
+            "1", word, "", "",
+            Collections.emptyList(), Collections.emptyList(), "",
+            Collections.emptyList(), Collections.emptyList(), "", Collections.emptyList(),
+            10, "", "", "",
+            "",
+            Collections.emptyList()
+        )
+    );
+
+    when(wordService.getDefinitions(word)).thenReturn(definitions);
+
+    mockMvc.perform(get("/word.json/{word}/definitions", word)
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].word").value(word));
+  }
+
+  @Test
+  @DisplayName("단어 정의 조회 실패")
+  void getDefinitions_Fail() throws Exception {
+    String word = "nonexistent";
+
+    when(wordService.getDefinitions(word)).thenReturn(Collections.emptyList());
+
+    mockMvc.perform(get("/word.json/{word}/definitions", word)
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$").isEmpty());
+  }
+
+  @Test
+  @DisplayName("예제 조회 성공")
+  void getExamples_Success() throws Exception {
+    String word = "test";
+    WordExampleDto example = new WordExampleDto(Collections.singletonList(
+        new WordExampleDto.ExampleDto(
+            new WordExampleDto.ProviderDto(1), 2024, 5, "", word,
+            "", 1001, 2001, "",
+            "Hyunjun Lee"
+        )
+    ));
+
+    when(wordService.getExamples(word)).thenReturn(example);
+
+    mockMvc.perform(get("/word.json/{word}/examples", word)
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.examples[0].word").value(word));
+  }
+
+  @Test
+  @DisplayName("예제 조회 실패")
+  void getExamples_Fail() throws Exception {
+    String word = "test";
+
+    when(wordService.getExamples(word)).thenReturn(null);
+
+    mockMvc.perform(get("/word.json/{word}/examples", word)
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.examples").doesNotExist());
+  }
+
+  @Test
+  @DisplayName("관련 단어 조회 성공")
+  void getRelatedWords_Success() throws Exception {
+    String word = "test";
+    List<WordRelatedWordDto> relatedWords = Collections.singletonList(
+        new WordRelatedWordDto("synonym", List.of("experiment", "trial"))
+    );
+
+    when(wordService.getRelatedWords(word)).thenReturn(relatedWords);
+
+    mockMvc.perform(get("/word.json/{word}/relatedWords", word)
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].relationshipType").value("synonym"));
+  }
+
+  @Test
+  @DisplayName("관련 단어 조회 실패")
+  void getRelatedWords_Fail() throws Exception {
+    String word = "test";
+
+    when(wordService.getRelatedWords(word)).thenReturn(Collections.emptyList());
+
+    mockMvc.perform(get("/word.json/{word}/relatedWords", word)
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$").isEmpty());
+  }
+
+  @Test
+  @DisplayName("단어 발음 조회 성공")
+  void getPronunciations_Success() throws Exception {
+    String word = "test";
+    List<WordPronunciationDto> pronunciations = Collections.singletonList(
+        new WordPronunciationDto(1, "tɛst", "IPA", "123", "", "")
+    );
+
+    when(wordService.getPronunciations(word)).thenReturn(pronunciations);
+
+    mockMvc.perform(get("/word.json/{word}/pronunciations", word)
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].raw").value("tɛst"));
+  }
+
+  @Test
+  @DisplayName("단어 발음 조회 실패")
+  void getPronunciations_Fail() throws Exception {
+    String word = "test";
+
+    when(wordService.getPronunciations(word)).thenReturn(Collections.emptyList());
+
+    mockMvc.perform(get("/word.json/{word}/pronunciations", word)
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$").isEmpty());
+  }
+
+  @Test
+  @DisplayName("단어 어원 조회 성공")
+  void getEtymologies_Success() throws Exception {
+    String word = "test";
+    List<WordEtymologyDto> etymologies = Collections.singletonList(
+        new WordEtymologyDto(
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<ety>[L. <ets>testis</ets>.  Cf. <er>Testament</er>, <er>Testify</er>.]</ety>\n")
+    );
+
+    when(wordService.getEtymologies(word)).thenReturn(etymologies);
+
+    mockMvc.perform(get("/word.json/{word}/etymologies", word)
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].etymologies").value(
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<ety>[L. <ets>testis</ets>.  Cf. <er>Testament</er>, <er>Testify</er>.]</ety>\n"));
+  }
+
+  @Test
+  @DisplayName("단어 어원 조회 실패")
+  void getEtymologies_Fail() throws Exception {
+    String word = "nonexistent";
+
+    when(wordService.getEtymologies(word)).thenReturn(Collections.emptyList());
+
+    mockMvc.perform(get("/word.json/{word}/etymologies", word)
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$").isEmpty());
+  }
+
+  @Test
+  @DisplayName("자동 완성 조회 성공")
+  void autocomplete_Success() throws Exception {
+    String word = "test";
+    List<String> suggestions = Collections.singletonList(word);
+
+    when(wordService.autocomplete(word)).thenReturn(suggestions);
+
+    mockMvc.perform(get("/word.json/autocomplete")
+            .param("word", word)
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0]").value(word));
+  }
+
+  @Test
+  @DisplayName("자동 완성 조회 실패")
+  void autocomplete_Fail() throws Exception {
+    String word = "test";
+
+    when(wordService.autocomplete(word)).thenReturn(Collections.emptyList());
+
+    mockMvc.perform(get("/word.json/autocomplete")
+            .param("word", word)
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$").isEmpty());
+  }
+}

--- a/src/test/java/com/github/Hyun_jun_Lee0811/dictionary/service/WordServiceTest.java
+++ b/src/test/java/com/github/Hyun_jun_Lee0811/dictionary/service/WordServiceTest.java
@@ -52,8 +52,7 @@ public class WordServiceTest {
 
     when(wordnikClient.getDefinitions(word)).thenReturn(expectedDefinitions);
 
-    List<WordDefinitionDto> definitions = wordService.getDefinitions(word);
-    assertEquals(expectedDefinitions, definitions);
+    assertEquals(expectedDefinitions, wordService.getDefinitions(word));
   }
 
   @Test
@@ -73,8 +72,7 @@ public class WordServiceTest {
 
     when(wordnikClient.getDefinitions(word)).thenReturn(Collections.emptyList());
 
-    List<WordDefinitionDto> definitions = wordService.getDefinitions(word);
-    assertNotEquals(expectedDefinitions, definitions);
+    assertNotEquals(expectedDefinitions, wordService.getDefinitions(word));
   }
 
   @Test
@@ -91,8 +89,7 @@ public class WordServiceTest {
 
     when(wordnikClient.getExamples(word)).thenReturn(example);
 
-    WordExampleDto examples = wordService.getExamples(word);
-    assertEquals(example, examples);
+    assertEquals(example, wordService.getExamples(word));
   }
 
   @Test
@@ -109,8 +106,7 @@ public class WordServiceTest {
 
     when(wordnikClient.getExamples(word)).thenReturn(new WordExampleDto(Collections.emptyList()));
 
-    WordExampleDto examples = wordService.getExamples(word);
-    assertNotEquals(example, examples);
+    assertNotEquals(example, wordService.getExamples(word));
   }
 
   @Test
@@ -123,8 +119,7 @@ public class WordServiceTest {
 
     when(wordnikClient.getRelatedWords(word)).thenReturn(relatedWords);
 
-    List<WordRelatedWordDto> result = wordService.getRelatedWords(word);
-    assertEquals(relatedWords, result);
+    assertEquals(relatedWords, wordService.getRelatedWords(word));
   }
 
   @Test
@@ -137,8 +132,7 @@ public class WordServiceTest {
 
     when(wordnikClient.getRelatedWords(word)).thenReturn(Collections.emptyList());
 
-    List<WordRelatedWordDto> result = wordService.getRelatedWords(word);
-    assertNotEquals(relatedWords, result);
+    assertNotEquals(relatedWords, wordService.getRelatedWords(word));
   }
 
   @Test
@@ -152,8 +146,7 @@ public class WordServiceTest {
 
     when(wordnikClient.getPronunciations(word)).thenReturn(pronunciations);
 
-    List<WordPronunciationDto> result = wordService.getPronunciations(word);
-    assertEquals(pronunciations, result);
+    assertEquals(pronunciations, wordService.getPronunciations(word));
   }
 
   @Test
@@ -170,8 +163,7 @@ public class WordServiceTest {
             "")
     ));
 
-    List<WordPronunciationDto> result = wordService.getPronunciations(word);
-    assertNotEquals(pronunciations, result);
+    assertNotEquals(pronunciations, wordService.getPronunciations(word));
   }
 
   @Test
@@ -184,8 +176,7 @@ public class WordServiceTest {
 
     when(wordnikClient.getEtymologies(word)).thenReturn(etymologies);
 
-    List<WordEtymologyDto> result = wordService.getEtymologies(word);
-    assertEquals(etymologies, result);
+    assertEquals(etymologies, wordService.getEtymologies(word));
   }
 
   @Test
@@ -200,8 +191,7 @@ public class WordServiceTest {
         new WordEtymologyDto("From New 'tests'.")
     ));
 
-    List<WordEtymologyDto> result = wordService.getEtymologies(word);
-    assertNotEquals(etymologies, result);
+    assertNotEquals(etymologies, wordService.getEtymologies(word));
   }
 
 
@@ -214,8 +204,7 @@ public class WordServiceTest {
 
     when(trie.prefixMap(word)).thenReturn(expectedMap);
 
-    List<String> suggestions = wordService.autocomplete(word);
-    assertEquals(Collections.singletonList(word), suggestions);
+    assertEquals(Collections.singletonList(word), wordService.autocomplete(word));
   }
 
   @Test
@@ -227,7 +216,6 @@ public class WordServiceTest {
 
     when(trie.prefixMap(word)).thenReturn(differentMap);
 
-    List<String> suggestions = wordService.autocomplete(word);
-    assertNotEquals(Collections.singletonList(word), suggestions);
+    assertNotEquals(Collections.singletonList(word), wordService.autocomplete(word));
   }
 }

--- a/src/test/java/com/github/Hyun_jun_Lee0811/dictionary/service/WordServiceTest.java
+++ b/src/test/java/com/github/Hyun_jun_Lee0811/dictionary/service/WordServiceTest.java
@@ -1,0 +1,233 @@
+package com.github.Hyun_jun_Lee0811.dictionary.service;
+
+import com.github.Hyun_jun_Lee0811.dictionary.client.WordnikClient;
+import com.github.Hyun_jun_Lee0811.dictionary.model.dto.*;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import org.apache.commons.collections4.Trie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class WordServiceTest {
+
+  @Mock
+  private WordnikClient wordnikClient;
+
+  @Mock
+  private Trie<String, Boolean> trie;
+
+  @InjectMocks
+  private WordService wordService;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+  }
+
+  @Test
+  @DisplayName("단어 정의 조회 성공")
+  void GetDefinitions_Success() {
+    String word = "test";
+    List<WordDefinitionDto> expectedDefinitions = Collections.singletonList(
+        new WordDefinitionDto(
+            "1", word, "", "",
+            Collections.emptyList(), Collections.emptyList(), "",
+            Collections.emptyList(), Collections.emptyList(), "", Collections.emptyList(),
+            10, "", "", "",
+            "",
+            Collections.emptyList()
+        )
+    );
+
+    when(wordnikClient.getDefinitions(word)).thenReturn(expectedDefinitions);
+
+    List<WordDefinitionDto> definitions = wordService.getDefinitions(word);
+    assertEquals(expectedDefinitions, definitions);
+  }
+
+  @Test
+  @DisplayName("단어 정의 조회 실패")
+  void GetDefinitions_Fail() {
+    String word = "test";
+    List<WordDefinitionDto> expectedDefinitions = Collections.singletonList(
+        new WordDefinitionDto(
+            "1", word, "", "",
+            Collections.emptyList(), Collections.emptyList(), "",
+            Collections.emptyList(), Collections.emptyList(), "", Collections.emptyList(),
+            10, "", "", "",
+            "",
+            Collections.emptyList()
+        )
+    );
+
+    when(wordnikClient.getDefinitions(word)).thenReturn(Collections.emptyList());
+
+    List<WordDefinitionDto> definitions = wordService.getDefinitions(word);
+    assertNotEquals(expectedDefinitions, definitions);
+  }
+
+  @Test
+  @DisplayName("예제 조회 성공")
+  void GetExamples_Success() {
+    String word = "test";
+    WordExampleDto example = new WordExampleDto(Collections.singletonList(
+        new WordExampleDto.ExampleDto(
+            new WordExampleDto.ProviderDto(1), 2024, 5, "", word,
+            "", 1001, 2001, "",
+            "Hyunjun Lee"
+        )
+    ));
+
+    when(wordnikClient.getExamples(word)).thenReturn(example);
+
+    WordExampleDto examples = wordService.getExamples(word);
+    assertEquals(example, examples);
+  }
+
+  @Test
+  @DisplayName("예제 조회 실패")
+  void GetExamples_Fail() {
+    String word = "test";
+    WordExampleDto example = new WordExampleDto(Collections.singletonList(
+        new WordExampleDto.ExampleDto(
+            new WordExampleDto.ProviderDto(1), 2024, 5, "", word,
+            "", 1001, 2001, "",
+            "Hyunjun Lee"
+        )
+    ));
+
+    when(wordnikClient.getExamples(word)).thenReturn(new WordExampleDto(Collections.emptyList()));
+
+    WordExampleDto examples = wordService.getExamples(word);
+    assertNotEquals(example, examples);
+  }
+
+  @Test
+  @DisplayName("관련 단어 조회 성공")
+  void GetRelatedWords_Success() {
+    String word = "test";
+    List<WordRelatedWordDto> relatedWords = Collections.singletonList(
+        new WordRelatedWordDto("synonym", List.of("experiment", "trial"))
+    );
+
+    when(wordnikClient.getRelatedWords(word)).thenReturn(relatedWords);
+
+    List<WordRelatedWordDto> result = wordService.getRelatedWords(word);
+    assertEquals(relatedWords, result);
+  }
+
+  @Test
+  @DisplayName("관련 단어 조회 실패")
+  void GetRelatedWords_Fail() {
+    String word = "test";
+    List<WordRelatedWordDto> relatedWords = Collections.singletonList(
+        new WordRelatedWordDto("synonym", List.of("experiment", "trial"))
+    );
+
+    when(wordnikClient.getRelatedWords(word)).thenReturn(Collections.emptyList());
+
+    List<WordRelatedWordDto> result = wordService.getRelatedWords(word);
+    assertNotEquals(relatedWords, result);
+  }
+
+  @Test
+  @DisplayName("단어 발음 조회 성공")
+  void GetPronunciations_Success() {
+    String word = "test";
+    List<WordPronunciationDto> pronunciations = Collections.singletonList(
+        new WordPronunciationDto(1, "tɛst", "IPA", "123", "",
+            "")
+    );
+
+    when(wordnikClient.getPronunciations(word)).thenReturn(pronunciations);
+
+    List<WordPronunciationDto> result = wordService.getPronunciations(word);
+    assertEquals(pronunciations, result);
+  }
+
+  @Test
+  @DisplayName("단어 발음 조회 실패")
+  void GetPronunciations_Fail() {
+    String word = "test";
+    List<WordPronunciationDto> pronunciations = Collections.singletonList(
+        new WordPronunciationDto(1, "tɛst", "IPA", "123", "",
+            "")
+    );
+
+    when(wordnikClient.getPronunciations(word)).thenReturn(Collections.singletonList(
+        new WordPronunciationDto(2, "tɛst", "IPA", "124", "",
+            "")
+    ));
+
+    List<WordPronunciationDto> result = wordService.getPronunciations(word);
+    assertNotEquals(pronunciations, result);
+  }
+
+  @Test
+  @DisplayName("단어 어원 조회 성공")
+  void GetEtymologies_Success() {
+    String word = "test";
+    List<WordEtymologyDto> etymologies = Collections.singletonList(
+        new WordEtymologyDto("From Old 'test'")
+    );
+
+    when(wordnikClient.getEtymologies(word)).thenReturn(etymologies);
+
+    List<WordEtymologyDto> result = wordService.getEtymologies(word);
+    assertEquals(etymologies, result);
+  }
+
+  @Test
+  @DisplayName("단어 어원 조회 실패")
+  void GetEtymologies_Fail() {
+    String word = "test";
+    List<WordEtymologyDto> etymologies = Collections.singletonList(
+        new WordEtymologyDto("From Old 'test'")
+    );
+
+    when(wordnikClient.getEtymologies(word)).thenReturn(Collections.singletonList(
+        new WordEtymologyDto("From New 'tests'.")
+    ));
+
+    List<WordEtymologyDto> result = wordService.getEtymologies(word);
+    assertNotEquals(etymologies, result);
+  }
+
+
+  @Test
+  @DisplayName("자동 완성 성공")
+  void Autocomplete_Success() {
+    String word = "test";
+    SortedMap<String, Boolean> expectedMap = new TreeMap<>();
+    expectedMap.put(word, Boolean.TRUE);
+
+    when(trie.prefixMap(word)).thenReturn(expectedMap);
+
+    List<String> suggestions = wordService.autocomplete(word);
+    assertEquals(Collections.singletonList(word), suggestions);
+  }
+
+  @Test
+  @DisplayName("자동 완성 실패")
+  void testAutocomplete_Fail() {
+    String word = "test";
+    SortedMap<String, Boolean> differentMap = new TreeMap<>();
+    differentMap.put("tests", true);
+
+    when(trie.prefixMap(word)).thenReturn(differentMap);
+
+    List<String> suggestions = wordService.autocomplete(word);
+    assertNotEquals(Collections.singletonList(word), suggestions);
+  }
+}


### PR DESCRIPTION
### 변경사항
*AS-IS*
- JWT를 적용한 회원 가입, 로그인, 비밀번호 변경, 이름 변경, 계정 삭제 API 사용자 관련 기능이 구현되어 있었습니다.
- 에러를 처리하기 위한 ErrorCode 및 ErrorResponse 클래스가 구현되었습니다.
- MariaDB와 연동되어 있었습니다.

**TO-BE**
- Wordnik API와 ElasticSearch를 활용하여 단어 검색 및 관련 기능을 추가했습니다:
- Trie 데이터 구조를 사용하여 단어 자동 완성 기능을 구현했습니다.
- WordnikClient를 통해 외부 API 호출을 처리하며, WordService에서 단어 정보를 조회하도록 설계했습니다.
- WordController를 통해 단어 관련 요청을 처리하였습니다.
- RestTemplateConfig 및 ElasticSearchConfig 설정 파일을 추가하여 외부 API 호출과 ElasticSearch 설정을 완료했습니다.
  - Amazon OpenSearch Service 도메인에 연결하기 위한  URL을 추가했습니다.
- Word DTO 클래스 작성하여 API 응답을 처리합니다.
### 테스트
- [x] 테스트 코드
- WordServiceTest: 단어 정의, 예제, 관련 단어, 발음, 어원 조회에 대한 성공 및 실패 테스트를 추가했습니다.
- WordControllerTest: 각 API 엔드포인트에 대한 성공 및 실패 테스트를 추가했습니다.
- [x] API 테스트 
- 정의 조회 API: 단어 정의를 정상적으로 조회할 수 있는지 확인했습니다.
- 예제 조회 API: 단어 예제를 정상적으로 조회할 수 있는지 확인했습니다.
- 관련 단어 조회 API: 단어와 관련된 단어들을 정상적으로 조회할 수 있는지 확인했습니다.
- 발음 조회 API: 단어의 발음 정보를 정상적으로 조회할 수 있는지 확인했습니다.
- 어원 조회 API: 단어의 어원 정보를 정상적으로 조회할 수 있는지 확인했습니다.
- 자동 완성 API: 입력된 검색어에 대해 가능한 단어 목록을 정상적으로 조회할 수 있는지 확인했습니다.