### PR TITLE
feat: 사용자의 단어장  기능 구현

### DIFF
--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/controller/UserThinkController.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/controller/UserThinkController.java
@@ -1,0 +1,66 @@
+package com.github.Hyun_jun_Lee0811.dictionary.controller;
+
+import com.github.Hyun_jun_Lee0811.dictionary.model.UserThinkForm;
+import com.github.Hyun_jun_Lee0811.dictionary.model.dto.UserThinkDTO;
+import com.github.Hyun_jun_Lee0811.dictionary.service.UserThinkService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/user-think")
+@RequiredArgsConstructor
+public class UserThinkController {
+
+  private final UserThinkService userThinkService;
+
+  @PostMapping("/save")
+  public ResponseEntity<Void> saveUserThink(@Valid @RequestBody UserThinkForm userThinkForm) {
+
+    userThinkService.saveUserThink(userThinkForm);
+    return ResponseEntity.ok().build();
+  }
+
+  @GetMapping("/my-thoughts/{username}")
+  public ResponseEntity<Page<UserThinkDTO>> getUserThoughts(@Valid
+  @PathVariable("username") String username,
+      @RequestParam(name = "page", defaultValue = "0") int page,
+      @RequestParam(name = "size", defaultValue = "10") int size) {
+
+    if (!userThinkService.isUserAuthenticated(username)) {
+      return ResponseEntity.status(403).build();
+    }
+
+    return ResponseEntity.ok(
+        userThinkService.getUserThoughts(username, PageRequest.of(page, size)));
+  }
+
+  @GetMapping("/public/{username}")
+  public ResponseEntity<List<UserThinkDTO>> getPublicThoughts(
+      @Valid @PathVariable("username") String username) {
+
+    List<UserThinkDTO> publicThoughts = userThinkService.getPublicThoughts(username);
+    return ResponseEntity.ok(publicThoughts);
+  }
+
+  @GetMapping("/word/{username}/{wordId}")
+  public ResponseEntity<List<UserThinkDTO>> getUserThinksByWord(
+      @Valid @PathVariable("username") String username, @PathVariable("wordId") String wordId) {
+
+    List<UserThinkDTO> userThinkDTOs = userThinkService.getUserThinksByWord(username, wordId);
+    return ResponseEntity.ok(userThinkDTOs);
+  }
+
+  @DeleteMapping("/delete/{username}/{id}")
+  public ResponseEntity<Void> deleteUserThink(@Valid @PathVariable("username") String username,
+      @PathVariable("id") Long id) {
+
+    userThinkService.deleteUserThink(username, id);
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/controller/UserThinkController.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/controller/UserThinkController.java
@@ -2,6 +2,7 @@ package com.github.Hyun_jun_Lee0811.dictionary.controller;
 
 import com.github.Hyun_jun_Lee0811.dictionary.model.UserThinkForm;
 import com.github.Hyun_jun_Lee0811.dictionary.model.dto.UserThinkDTO;
+import com.github.Hyun_jun_Lee0811.dictionary.security.JwtAuthenticationFilter;
 import com.github.Hyun_jun_Lee0811.dictionary.service.UserThinkService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -13,13 +14,14 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/user-think")
+@RequestMapping("/user-thinks")
 @RequiredArgsConstructor
 public class UserThinkController {
 
   private final UserThinkService userThinkService;
+  private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
-  @PostMapping("/save")
+  @PostMapping
   public ResponseEntity<Void> saveUserThink(@Valid @RequestBody UserThinkForm userThinkForm) {
 
     userThinkService.saveUserThink(userThinkForm);
@@ -32,7 +34,7 @@ public class UserThinkController {
       @RequestParam(name = "page", defaultValue = "0") int page,
       @RequestParam(name = "size", defaultValue = "10") int size) {
 
-    if (!userThinkService.isUserAuthenticated(username)) {
+    if (!jwtAuthenticationFilter.isUserAuthenticated(username)) {
       return ResponseEntity.status(403).build();
     }
 
@@ -44,16 +46,14 @@ public class UserThinkController {
   public ResponseEntity<List<UserThinkDTO>> getPublicThoughts(
       @Valid @PathVariable("username") String username) {
 
-    List<UserThinkDTO> publicThoughts = userThinkService.getPublicThoughts(username);
-    return ResponseEntity.ok(publicThoughts);
+    return ResponseEntity.ok(userThinkService.getPublicThoughts(username));
   }
 
   @GetMapping("/word/{username}/{wordId}")
   public ResponseEntity<List<UserThinkDTO>> getUserThinksByWord(
       @Valid @PathVariable("username") String username, @PathVariable("wordId") String wordId) {
 
-    List<UserThinkDTO> userThinkDTOs = userThinkService.getUserThinksByWord(username, wordId);
-    return ResponseEntity.ok(userThinkDTOs);
+    return ResponseEntity.ok(userThinkService.getUserThinksByWord(username, wordId));
   }
 
   @PutMapping("/change-think/{id}")

--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/controller/UserThinkController.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/controller/UserThinkController.java
@@ -56,6 +56,15 @@ public class UserThinkController {
     return ResponseEntity.ok(userThinkDTOs);
   }
 
+  @PutMapping("/change-think/{id}")
+  public ResponseEntity<Void> changeUserThink(
+      @PathVariable("id") Long id,
+      @RequestBody UserThinkForm userThinkForm) {
+
+    userThinkService.changeUserThink(id, userThinkForm);
+    return ResponseEntity.ok().build();
+  }
+
   @DeleteMapping("/delete/{username}/{id}")
   public ResponseEntity<Void> deleteUserThink(@Valid @PathVariable("username") String username,
       @PathVariable("id") Long id) {

--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/controller/WordBookController.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/controller/WordBookController.java
@@ -1,0 +1,31 @@
+package com.github.Hyun_jun_Lee0811.dictionary.controller;
+
+import com.github.Hyun_jun_Lee0811.dictionary.model.dto.WordBookDTO;
+import com.github.Hyun_jun_Lee0811.dictionary.service.WordBookService;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/wordbook")
+@RequiredArgsConstructor
+public class WordBookController {
+
+  private final WordBookService wordBookService;
+
+  @GetMapping("/search/{username}/{wordId}")
+  public ResponseEntity<List<WordBookDTO>> getWordBookByUsernameAndWordId(
+      @Valid @PathVariable("username") String username,
+      @PathVariable("wordId") String wordId) {
+
+    if (!wordBookService.isUserAuthenticated(username)) {
+      return ResponseEntity.status(403).build();
+    }
+    return ResponseEntity.ok(wordBookService.getWordBookByUsernameAndWordId(username, wordId));
+  }
+}

--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/model/UserThinkForm.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/model/UserThinkForm.java
@@ -7,9 +7,11 @@ import lombok.Data;
 
 @Data
 public class UserThinkForm {
+
   @NotBlank(message = "Username cannot be empty")
   private String username;
 
+  @NotBlank(message = "WordId cannot be empty")
   private String wordId;
 
   @NotBlank(message = "Word cannot be empty")
@@ -19,7 +21,7 @@ public class UserThinkForm {
   @Size(max = 1000, message = "User think content must be less than or equal to 1000 characters")
   private String userThink;
 
-  private Boolean isPrivate;
+  private Boolean isPrivate = false;
 
   public UserThinkDTO toDTO() {
     return UserThinkDTO.builder()

--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/model/UserThinkForm.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/model/UserThinkForm.java
@@ -1,0 +1,33 @@
+package com.github.Hyun_jun_Lee0811.dictionary.model;
+
+import com.github.Hyun_jun_Lee0811.dictionary.model.dto.UserThinkDTO;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Data
+public class UserThinkForm {
+  @NotBlank(message = "Username cannot be empty")
+  private String username;
+
+  private String wordId;
+
+  @NotBlank(message = "Word cannot be empty")
+  private String word;
+
+  @NotBlank(message = "User think content is required")
+  @Size(max = 1000, message = "User think content must be less than or equal to 1000 characters")
+  private String userThink;
+
+  private Boolean isPrivate;
+
+  public UserThinkDTO toDTO() {
+    return UserThinkDTO.builder()
+        .username(this.username)
+        .wordId(this.wordId)
+        .word(this.word)
+        .userThink(this.userThink)
+        .isPrivate(this.isPrivate)
+        .build();
+  }
+}

--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/model/dto/UserDto.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/model/dto/UserDto.java
@@ -1,17 +1,26 @@
 package com.github.Hyun_jun_Lee0811.dictionary.model.dto;
 
+import java.util.Collection;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
 
 @Getter
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
-public class UserDto {
+public class UserDto implements UserDetails {
 
   private Long id;
   private String username;
   private String password;
+
+  @Override
+  public Collection<? extends GrantedAuthority> getAuthorities() {
+    return List.of();
+  }
 }

--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/model/dto/UserThinkDTO.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/model/dto/UserThinkDTO.java
@@ -18,11 +18,12 @@ public class UserThinkDTO {
   private Long id;
   @NotBlank(message = "Username cannot be empty")
   private String username;
+  @NotBlank(message = "WordId cannot be empty")
   private String wordId;
   @NotBlank(message = "Word cannot be empty")
   private String word;
   @NotBlank(message = "User think content is required")
   @Size(max = 1000, message = "User think content must be less than or equal to 1000 characters")
   private String userThink;
-  private Boolean isPrivate;
+  private Boolean isPrivate = false;
 }

--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/model/dto/UserThinkDTO.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/model/dto/UserThinkDTO.java
@@ -1,0 +1,28 @@
+package com.github.Hyun_jun_Lee0811.dictionary.model.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserThinkDTO {
+
+  private Long id;
+  @NotBlank(message = "Username cannot be empty")
+  private String username;
+  private String wordId;
+  @NotBlank(message = "Word cannot be empty")
+  private String word;
+  @NotBlank(message = "User think content is required")
+  @Size(max = 1000, message = "User think content must be less than or equal to 1000 characters")
+  private String userThink;
+  private Boolean isPrivate;
+}

--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/model/dto/WordBookDTO.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/model/dto/WordBookDTO.java
@@ -1,0 +1,24 @@
+package com.github.Hyun_jun_Lee0811.dictionary.model.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class WordBookDTO {
+
+  private String word;
+  private String wordId;
+  private List<WordBookEntryDTO> thinks;
+  private LocalDateTime createdAt;
+  private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/model/dto/WordBookEntryDTO.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/model/dto/WordBookEntryDTO.java
@@ -1,0 +1,18 @@
+package com.github.Hyun_jun_Lee0811.dictionary.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class WordBookEntryDTO {
+
+  private Long id;
+  private String userThink;
+}

--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/model/entity/UserThink.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/model/entity/UserThink.java
@@ -1,0 +1,73 @@
+package com.github.Hyun_jun_Lee0811.dictionary.model.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "user_thinks")
+public class UserThink {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @NotNull
+  @Column(name = "USER_ID", nullable = false)
+  private Long userId;
+
+  @NotNull
+  @Column(name = "WORD_ID")
+  private String wordId;
+
+  @NotNull
+  @Column(name = "WORD", nullable = false)
+  private String word;
+
+  @Column(name = "USER_THINK")
+  @NotBlank(message = "User think content is required")
+  @Size(max = 1000, message = "User think content must be less than or equal to 1000 characters")
+  private String userThink;
+
+  @Column(name = "IS_PRIVATE")
+  private Boolean isPrivate;
+
+  @NotNull
+  @Column(name = "CREATED_AT", nullable = false)
+  private LocalDateTime createdAt;
+
+  @Column(name = "UPDATED_AT")
+  private LocalDateTime updatedAt;
+
+  @Column(name = "DELETED_AT")
+  private LocalDateTime deletedAt;
+
+  @PrePersist
+  protected void onCreate() {
+    this.createdAt = LocalDateTime.now();
+  }
+
+  @PreUpdate
+  protected void onUpdate() {
+    this.updatedAt = LocalDateTime.now();
+  }
+}

--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/model/entity/UserThink.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/model/entity/UserThink.java
@@ -36,6 +36,7 @@ public class UserThink {
   private Long userId;
 
   @NotNull
+  @NotBlank(message = "WordId cannot be empty")
   @Column(name = "WORD_ID")
   private String wordId;
 
@@ -49,7 +50,7 @@ public class UserThink {
   private String userThink;
 
   @Column(name = "IS_PRIVATE")
-  private Boolean isPrivate;
+  private Boolean isPrivate = false;
 
   @NotNull
   @Column(name = "CREATED_AT", nullable = false)

--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/model/entity/WordBook.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/model/entity/WordBook.java
@@ -1,0 +1,59 @@
+package com.github.Hyun_jun_Lee0811.dictionary.model.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "word_books")
+public class WordBook {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "USER_ID", nullable = false)
+  private Long userId;
+
+  @NotNull
+  @Column(name = "WORD_ID", nullable = false)
+  private String wordId;
+
+  @NotNull
+  @Column(name = "WORD", nullable = false)
+  private String word;
+
+  @NotNull
+  @Column(name = "CREATED_AT", nullable = false)
+  private LocalDateTime createdAt;
+
+  @Column(name = "UPDATED_AT")
+  private LocalDateTime updatedAt;
+
+  @PrePersist
+  protected void onCreate() {
+    this.createdAt = LocalDateTime.now();
+  }
+
+  @PreUpdate
+  protected void onUpdate() {
+    this.updatedAt = LocalDateTime.now();
+  }
+}

--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/repository/UserThinkRepository.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/repository/UserThinkRepository.java
@@ -1,0 +1,16 @@
+package com.github.Hyun_jun_Lee0811.dictionary.repository;
+
+import com.github.Hyun_jun_Lee0811.dictionary.model.entity.UserThink;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserThinkRepository extends JpaRepository<UserThink, Long> {
+
+  List<UserThink> findByUserIdAndIsPrivate(Long userId, Boolean isPrivate);
+
+  List<UserThink> findByUserIdAndWordId(Long userId, String wordId);
+
+  Page<UserThink> findByUserId(Long userId, Pageable pageable);
+}

--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/repository/UserThinkRepository.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/repository/UserThinkRepository.java
@@ -15,4 +15,6 @@ public interface UserThinkRepository extends JpaRepository<UserThink, Long> {
   Page<UserThink> findByUserId(Long userId, Pageable pageable);
 
   long countByUserId(Long userId);
+
+  List<UserThink> findByUserIdAndWordIdAndIsPrivate(Long userId, String wordId, Boolean isPrivate);
 }

--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/repository/UserThinkRepository.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/repository/UserThinkRepository.java
@@ -13,4 +13,6 @@ public interface UserThinkRepository extends JpaRepository<UserThink, Long> {
   List<UserThink> findByUserIdAndWordId(Long userId, String wordId);
 
   Page<UserThink> findByUserId(Long userId, Pageable pageable);
+
+  long countByUserId(Long userId);
 }

--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/repository/WordBookRepository.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/repository/WordBookRepository.java
@@ -1,0 +1,10 @@
+package com.github.Hyun_jun_Lee0811.dictionary.repository;
+
+import com.github.Hyun_jun_Lee0811.dictionary.model.entity.WordBook;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WordBookRepository extends JpaRepository<WordBook, Long> {
+
+  Optional<WordBook> findByUserIdAndWord(Long userId, String word);
+}

--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/security/JwtAuthenticationFilter.java
@@ -1,5 +1,8 @@
 package com.github.Hyun_jun_Lee0811.dictionary.security;
 
+import static com.github.Hyun_jun_Lee0811.dictionary.type.ErrorCode.USER_NOT_AUTHENTICATED;
+
+import com.github.Hyun_jun_Lee0811.dictionary.expection.ErrorResponse;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -28,7 +31,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
   protected void doFilterInternal(
       @NonNull HttpServletRequest request,
       @NonNull HttpServletResponse response,
-      @NonNull  FilterChain filterChain) throws ServletException, IOException {
+      @NonNull FilterChain filterChain) throws ServletException, IOException {
 
     String token = resolveToken(request);
     if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
@@ -36,6 +39,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
       SecurityContextHolder.getContext().setAuthentication(authentication);
     }
     filterChain.doFilter(request, response);
+  }
+
+  public boolean isUserAuthenticated(String username) {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    if (authentication == null || !authentication.isAuthenticated()) {
+      throw new ErrorResponse(USER_NOT_AUTHENTICATED);
+    }
+
+    return username.equals(authentication.getName());
   }
 
   private String resolveToken(HttpServletRequest request) {

--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/security/JwtAuthenticationFilter.java
@@ -5,6 +5,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
@@ -25,9 +26,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
   @Override
   protected void doFilterInternal(
-      HttpServletRequest request,
-      HttpServletResponse response,
-      FilterChain filterChain) throws ServletException, IOException {
+      @NonNull HttpServletRequest request,
+      @NonNull HttpServletResponse response,
+      @NonNull  FilterChain filterChain) throws ServletException, IOException {
 
     String token = resolveToken(request);
     if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {

--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/service/UserThinkService.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/service/UserThinkService.java
@@ -1,0 +1,162 @@
+package com.github.Hyun_jun_Lee0811.dictionary.service;
+
+import static com.github.Hyun_jun_Lee0811.dictionary.type.ErrorCode.*;
+
+import com.github.Hyun_jun_Lee0811.dictionary.client.WordnikClient;
+import com.github.Hyun_jun_Lee0811.dictionary.expection.ErrorResponse;
+import com.github.Hyun_jun_Lee0811.dictionary.model.UserThinkForm;
+import com.github.Hyun_jun_Lee0811.dictionary.model.dto.UserThinkDTO;
+import com.github.Hyun_jun_Lee0811.dictionary.model.dto.WordDefinitionDto;
+import com.github.Hyun_jun_Lee0811.dictionary.model.entity.User;
+import com.github.Hyun_jun_Lee0811.dictionary.model.entity.UserThink;
+import com.github.Hyun_jun_Lee0811.dictionary.repository.UserThinkRepository;
+import com.github.Hyun_jun_Lee0811.dictionary.repository.UserRepository;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class UserThinkService {
+
+  private final UserThinkRepository userThinkRepository;
+  private final UserRepository userRepository;
+  private final WordnikClient wordnikClient;
+
+  public void saveUserThink(UserThinkForm userThinkForm) {
+    if (isUserAuthenticated(userThinkForm.getUsername())) {
+      throw new ErrorResponse(USER_NOT_AUTHENTICATED);
+    }
+
+    try {
+      userThinkRepository.save(UserThink.builder()
+          .userId(getUserIdByUsername(userThinkForm.toDTO().getUsername()))
+          .wordId(determineWordId(
+              userThinkForm.toDTO(),
+              wordnikClient.getDefinitions(userThinkForm.toDTO().getWord())))
+
+          .word(userThinkForm.toDTO().getWord())
+          .userThink(userThinkForm.toDTO().getUserThink())
+          .isPrivate(userThinkForm.toDTO().getIsPrivate())
+          .createdAt(LocalDateTime.now())
+          .build());
+
+    } catch (RuntimeException e) {
+      throw new ErrorResponse(FAILED_SAVE);
+    }
+  }
+
+  public Page<UserThinkDTO> getUserThoughts(String username, Pageable pageable) {
+    return userThinkRepository.findByUserId(getUserIdByUsername(username), pageable)
+        .map(this::mapToDTO);
+  }
+
+  public List<UserThinkDTO> getPublicThoughts(String username) {
+    return userThinkRepository.findByUserIdAndIsPrivate(getUserIdByUsername(username), false)
+        .stream()
+        .map(this::mapToDTO)
+        .collect(Collectors.toList());
+  }
+
+  public List<UserThinkDTO> getUserThinksByWord(String username, String wordId) {
+    List<UserThink> userThinks = userThinkRepository.findByUserIdAndWordId(
+        getUserIdByUsername(username), wordId);
+
+    if (userThinks.isEmpty()) {
+      throw new ErrorResponse(NO_USERTHINKS_FOUND_OR_ACCESS_DENIED);
+    }
+
+    return userThinks.stream()
+        .filter(think -> !think.getIsPrivate() || isUserAuthenticated(username))
+        .map(this::mapToDTO)
+        .collect(Collectors.toList());
+  }
+
+  //사용자가 입력한 이름과 토큰 발급 시 사용된 이름과 일치하는지 확인하는 메서드
+  public boolean isUserAuthenticated(String username) {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    if (authentication == null || !authentication.isAuthenticated()) {
+      return false;
+    }
+
+    return username.equals(authentication.getName());
+  }
+
+  public void deleteUserThink(String username, Long id) {
+    UserThink userThink = userThinkRepository.findById(id)
+        .orElseThrow(() -> new ErrorResponse(NO_USERTHINKS_FOUND_OR_ACCESS_DENIED));
+
+    if (!isUserAuthenticated(username)) {
+      throw new ErrorResponse(USER_NOT_AUTHENTICATED);
+    }
+
+    if (!userThink.getUserId().equals(getUserIdByUsername(username))) {
+      throw new ErrorResponse(NO_USERTHINKS_FOUND_OR_ACCESS_DENIED);
+    }
+    userThink.setDeletedAt(LocalDateTime.now());
+    userThinkRepository.delete(userThink);
+  }
+
+  //사용자 이름을 통해 아이디 가져오는 메서드
+  private Long getUserIdByUsername(String username) {
+    return userRepository.findByUsername(username)
+        .map(User::getUserId)
+        .orElseThrow(() -> new ErrorResponse(USER_NOT_EXIT));
+  }
+
+  // 단어 ID를 결정하여 반환하는 메서드 -> 사용자가 단어 ID를 미입력하면 입력한 단어의 첫번째 아이디로 적용
+  private String determineWordId(UserThinkDTO userThinkDTO, List<WordDefinitionDto> definitions) {
+    if (userThinkDTO.getWordId() != null && !userThinkDTO.getWordId().trim().isEmpty()) {
+      return validateAndReturnWordId(userThinkDTO.getWordId(), definitions);
+
+    } else {
+      return selectFirstValidWordId(definitions);
+    }
+  }
+
+  // 제공된 단어 ID가 유효한지 확인하고 반환하는 메서드
+  private String validateAndReturnWordId(String wordId, List<WordDefinitionDto> definitions) {
+    boolean validId = definitions.stream()
+        .anyMatch(definition -> definition.getId() != null && definition.getId().equals(wordId));
+
+    if (validId) {
+      return wordId;
+    } else {
+      throw new ErrorResponse(EXAMPLES_API_CLIENT_ERROR);
+    }
+  }
+
+  // 단의 정의 목록에서 첫 번째 유효한 단어 ID를 선택
+  private String selectFirstValidWordId(List<WordDefinitionDto> definitions) {
+    return definitions.isEmpty() ? USER_ID_NOT_PROVIDED.getMessage() :
+        definitions.stream()
+            .map(WordDefinitionDto::getId)
+            .filter(Objects::nonNull)
+            .findFirst()
+            .orElse(USER_ID_NOT_PROVIDED.getMessage());
+  }
+
+  // UserThink 엔티티를 UserThinkDTO로 변환하는 메서드
+  private UserThinkDTO mapToDTO(UserThink think) {
+    String username = userRepository.findById(think.getUserId())
+        .map(User::getUsername)
+        .orElse(ID_NOT_EXIT.getMessage());
+
+    return UserThinkDTO.builder()
+        .id(think.getId())
+        .username(username)
+        .wordId(think.getWordId())
+        .word(think.getWord())
+        .userThink(think.getUserThink())
+        .isPrivate(think.getIsPrivate())
+        .build();
+  }
+}

--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/service/UserThinkService.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/service/UserThinkService.java
@@ -33,10 +33,8 @@ public class UserThinkService {
   private static final int MAX_USER_THINKS = 100;
 
   public void saveUserThink(UserThinkForm userThinkForm) {
-    if (!isUserAuthenticated(userThinkForm.getUsername())) {
-      throw new ErrorResponse(USER_NOT_AUTHENTICATED);
-    }
 
+    isUserAuthenticated(userThinkForm.getUsername());
     checkUserThinkLimit(getUserIdByUsername(userThinkForm.getUsername()));
 
     userThinkRepository.save(UserThink.builder()
@@ -82,7 +80,7 @@ public class UserThinkService {
   public boolean isUserAuthenticated(String username) {
     Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
     if (authentication == null || !authentication.isAuthenticated()) {
-      return false;
+       throw new ErrorResponse(USER_NOT_AUTHENTICATED);
     }
 
     return username.equals(authentication.getName());

--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/service/UserThinkService.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/service/UserThinkService.java
@@ -90,6 +90,23 @@ public class UserThinkService {
     return username.equals(authentication.getName());
   }
 
+  public void changeUserThink(Long id, UserThinkForm userThinkForm) {
+    UserThink findUserThink = userThinkRepository.findById(id)
+        .orElseThrow(() -> new ErrorResponse(NO_USERTHINKS_FOUND_OR_ACCESS_DENIED));
+
+    String findUsername = userRepository.findById(findUserThink.getUserId())
+        .map(User::getUsername)
+        .orElseThrow(() -> new ErrorResponse(USER_NOT_EXIT));
+
+    if (!findUsername.equals(userThinkForm.getUsername())) {
+      throw new ErrorResponse(USER_NOT_AUTHENTICATED);
+    }
+
+    findUserThink.setUserThink(userThinkForm.getUserThink());
+    findUserThink.setUpdatedAt(LocalDateTime.now());
+    userThinkRepository.save(findUserThink);
+  }
+
   public void deleteUserThink(String username, Long id) {
     UserThink userThink = userThinkRepository.findById(id)
         .orElseThrow(() -> new ErrorResponse(NO_USERTHINKS_FOUND_OR_ACCESS_DENIED));

--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/service/WordBookService.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/service/WordBookService.java
@@ -23,14 +23,12 @@ public class WordBookService {
   private final UserRepository userRepository;
 
   public List<WordBookDTO> getWordBookByUsernameAndWordId(String username, String wordId) {
-    Long userId = getUserIdByUsername(username);
-    List<UserThink> userThinks = getFilteredUserThinks(userId, wordId);
 
-    if (userThinks.isEmpty()) {
+    if (getFilteredUserThinks(getUserIdByUsername(username), wordId).isEmpty()) {
       throw new ErrorResponse(ErrorCode.NO_USERTHINKS_FOUND_OR_ACCESS_DENIED);
     }
 
-    return convertToWordBookDTO(userThinks);
+    return convertToWordBookDTO(getFilteredUserThinks(getUserIdByUsername(username), wordId));
   }
 
   public boolean isUserAuthenticated(String username) {

--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/service/WordBookService.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/service/WordBookService.java
@@ -1,0 +1,82 @@
+package com.github.Hyun_jun_Lee0811.dictionary.service;
+
+import com.github.Hyun_jun_Lee0811.dictionary.expection.ErrorResponse;
+import com.github.Hyun_jun_Lee0811.dictionary.model.dto.WordBookEntryDTO;
+import com.github.Hyun_jun_Lee0811.dictionary.model.dto.WordBookDTO;
+import com.github.Hyun_jun_Lee0811.dictionary.model.entity.User;
+import com.github.Hyun_jun_Lee0811.dictionary.model.entity.UserThink;
+import com.github.Hyun_jun_Lee0811.dictionary.repository.UserThinkRepository;
+import com.github.Hyun_jun_Lee0811.dictionary.repository.UserRepository;
+import com.github.Hyun_jun_Lee0811.dictionary.type.ErrorCode;
+import java.time.LocalDateTime;
+import java.util.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class WordBookService {
+
+  private final UserThinkRepository userThinkRepository;
+  private final UserRepository userRepository;
+
+  public List<WordBookDTO> getWordBookByUsernameAndWordId(String username, String wordId) {
+    Long userId = getUserIdByUsername(username);
+    List<UserThink> userThinks = getFilteredUserThinks(userId, wordId);
+
+    if (userThinks.isEmpty()) {
+      throw new ErrorResponse(ErrorCode.NO_USERTHINKS_FOUND_OR_ACCESS_DENIED);
+    }
+
+    return convertToWordBookDTO(userThinks);
+  }
+
+  public boolean isUserAuthenticated(String username) {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    if (authentication == null || !authentication.isAuthenticated()) {
+      throw new ErrorResponse(ErrorCode.USER_NOT_AUTHENTICATED);
+    }
+
+    return username.equals(authentication.getName());
+  }
+
+  private List<UserThink> getFilteredUserThinks(Long userId, String wordId) {
+    return userThinkRepository.findByUserIdAndWordIdAndIsPrivate(userId, wordId, false);
+  }
+
+  private List<WordBookDTO> convertToWordBookDTO(List<UserThink> userThinks) {
+    Map<String, WordBookDTO> wordBookMap = new HashMap<>();
+
+    for (UserThink think : userThinks) {
+      wordBookMap.computeIfAbsent(think.getWord(), word ->
+          createWordBookDTO(think)).getThinks().add(createWordBookEntryDTO(think));
+    }
+
+    return new ArrayList<>(wordBookMap.values());
+  }
+
+  private WordBookDTO createWordBookDTO(UserThink think) {
+    return WordBookDTO.builder()
+        .word(think.getWord())
+        .wordId(think.getWordId())
+        .createdAt(think.getCreatedAt())
+        .updatedAt(Optional.ofNullable(think.getUpdatedAt()).orElse(LocalDateTime.now()))
+        .thinks(new ArrayList<>())
+        .build();
+  }
+
+  private WordBookEntryDTO createWordBookEntryDTO(UserThink think) {
+    return WordBookEntryDTO.builder()
+        .id(think.getId())
+        .userThink(think.getUserThink())
+        .build();
+  }
+
+  private Long getUserIdByUsername(String username) {
+    return userRepository.findByUsername(username)
+        .map(User::getUserId)
+        .orElseThrow(() -> new ErrorResponse(ErrorCode.USER_NOT_EXIT));
+  }
+}

--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/type/ErrorCode.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/type/ErrorCode.java
@@ -17,7 +17,12 @@ public enum ErrorCode {
   INVALID_JWT_TOKEN("JWT 토큰이 잘못되었습니다."),
   EXAMPLES_API_CLIENT_ERROR("API 호출 중 클라이언트 오류가 발생했습니다."),
   EXAMPLES_API_SERVER_ERROR("API 호출 중 서버 오류가 발생했습니다."),
-  EXAMPLES_API_NETWORK_ERROR("API 호출 중 네트워크 오류가 발생했습니다.");
-
+  EXAMPLES_API_NETWORK_ERROR("API 호출 중 네트워크 오류가 발생했습니다."),
+  USER_ID_NOT_PROVIDED("사용자 아이디가 제공되지 않았습니다."),
+  USER_NOT_AUTHENTICATED("인증된 사용자가 아닙니다"),
+  NO_USERTHINKS_FOUND_OR_ACCESS_DENIED("사용자의 생각을 찾을 수 없거나 접근이 거부되었습니다."),
+  INVALID_USERNAME("잘못된 사용자 이름 입니다."),
+  SERVICE_EXCEPTION("서비스에서 오류가 발생했습니다."),
+  FAILED_SAVE("저장에 실패했습니다");
   private final String message;
 }

--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/type/ErrorCode.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/type/ErrorCode.java
@@ -23,6 +23,7 @@ public enum ErrorCode {
   NO_USERTHINKS_FOUND_OR_ACCESS_DENIED("사용자의 생각을 찾을 수 없거나 접근이 거부되었습니다."),
   INVALID_USERNAME("잘못된 사용자 이름 입니다."),
   SERVICE_EXCEPTION("서비스에서 오류가 발생했습니다."),
-  FAILED_SAVE("저장에 실패했습니다");
+  MAX_USER_THINKS_EXCEEDED("사용자가 저장할 수 있는 최대 단어 생각 개수를 초과했습니다.");
+
   private final String message;
 }

--- a/src/test/java/com/github/Hyun_jun_Lee0811/dictionary/controller/UserThinkControllerTest.java
+++ b/src/test/java/com/github/Hyun_jun_Lee0811/dictionary/controller/UserThinkControllerTest.java
@@ -92,7 +92,7 @@ public class UserThinkControllerTest {
     when(userThinkService.isUserAuthenticated("이현준")).thenReturn(true);
     when(userThinkService.getUserThoughts(eq("이현준"), any(Pageable.class))).thenReturn(page);
 
-    mockMvc.perform(get("/user-think/이현준?page=0&size=10")
+    mockMvc.perform(get("/user-think/my-thoughts/이현준?page=0&size=10")
             .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.totalElements").value(2))

--- a/src/test/java/com/github/Hyun_jun_Lee0811/dictionary/controller/UserThinkControllerTest.java
+++ b/src/test/java/com/github/Hyun_jun_Lee0811/dictionary/controller/UserThinkControllerTest.java
@@ -108,7 +108,7 @@ public class UserThinkControllerTest {
   public void getUserThoughts_Fail() throws Exception {
     when(userThinkService.isUserAuthenticated("이현준")).thenReturn(false);
 
-    mockMvc.perform(get("/user-think/이현준?page=0&size=10")
+    mockMvc.perform(get("/user-think/my-thoughts/이현준?page=0&size=10")
             .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isForbidden());
 
@@ -174,6 +174,41 @@ public class UserThinkControllerTest {
         .andExpect(status().isInternalServerError());
 
     verify(userThinkService, times(1)).getUserThinksByWord(eq("이도현"), eq("C5097400-1"));
+  }
+
+  @Test
+  @DisplayName("자신의 생각 변경 성공")
+  public void changeUserThink_Success() throws Exception {
+    String jsonContent = "{ "
+        + "\"id\": 21, "
+        + "\"username\": \"이현준\", "
+        + "\"userThink\": \"변경\" }";
+
+    mockMvc.perform(put("/user-think/change-think/21")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(jsonContent))
+        .andExpect(status().isOk());
+
+    verify(userThinkService, times(1)).changeUserThink(eq(21L), any(UserThinkForm.class));
+  }
+
+  @Test
+  @DisplayName("자신의 생각 변경 실패 - 생각 없음")
+  public void changeUserThink_Fail_NotFound() throws Exception {
+    String jsonContent = "{ "
+        + "\"id\": 21, "
+        + "\"username\": \"이현준\", "
+        + "\"userThink\": \"변경\" }";
+
+    doThrow(new ErrorResponse(NO_USERTHINKS_FOUND_OR_ACCESS_DENIED)).when(userThinkService)
+        .changeUserThink(eq(21L), any(UserThinkForm.class));
+
+    mockMvc.perform(put("/user-think/change-think/21")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(jsonContent))
+        .andExpect(status().isNotFound());
+
+    verify(userThinkService, times(1)).changeUserThink(eq(21L), any(UserThinkForm.class));
   }
 
   @Test

--- a/src/test/java/com/github/Hyun_jun_Lee0811/dictionary/controller/UserThinkControllerTest.java
+++ b/src/test/java/com/github/Hyun_jun_Lee0811/dictionary/controller/UserThinkControllerTest.java
@@ -1,0 +1,201 @@
+package com.github.Hyun_jun_Lee0811.dictionary.controller;
+
+import com.github.Hyun_jun_Lee0811.dictionary.expection.ErrorResponse;
+import com.github.Hyun_jun_Lee0811.dictionary.model.UserThinkForm;
+import com.github.Hyun_jun_Lee0811.dictionary.model.dto.UserThinkDTO;
+import com.github.Hyun_jun_Lee0811.dictionary.service.UserThinkService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.Arrays;
+
+import static com.github.Hyun_jun_Lee0811.dictionary.type.ErrorCode.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+public class UserThinkControllerTest {
+
+  @Mock
+  private UserThinkService userThinkService;
+
+  @InjectMocks
+  private UserThinkController userThinkController;
+
+  private MockMvc mockMvc;
+
+  @BeforeEach
+  public void setUp() {
+    MockitoAnnotations.openMocks(this);
+    this.mockMvc = MockMvcBuilders.standaloneSetup(userThinkController).build();
+  }
+
+  @Test
+  @DisplayName("자신의 생각 저장 성공")
+  public void saveUserThink_Success() throws Exception {
+    String jsonContent = "{ "
+        + "\"username\": \"이현준\", "
+        + "\"wordId\": \"A5398300-1\", "
+        + "\"word\": \"apple\", "
+        + "\"userThink\": \"good\", "
+        + "\"isPrivate\": false }";
+
+    mockMvc.perform(post("/user-think/save")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(jsonContent))
+        .andExpect(status().isOk());
+
+    verify(userThinkService, times(1)).saveUserThink(any(UserThinkForm.class));
+  }
+
+  @Test
+  @DisplayName("자신의 생각 저장 실패")
+  public void saveUserThink_Fail() throws Exception {
+    String jsonContent = "{ "
+        + "\"username\": \"이현준\", "
+        + "\"wordId\": \"A5398300-1\", "
+        + "\"word\": \"apple\", "
+        + "\"userThink\": \"good\", "
+        + "\"isPrivate\": false }";
+
+    doThrow(new ErrorResponse(SERVICE_EXCEPTION)).when(userThinkService)
+        .saveUserThink(any(UserThinkForm.class));
+
+    mockMvc.perform(post("/user-think/save")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(jsonContent))
+        .andExpect(status().isInternalServerError());
+
+    verify(userThinkService, times(1)).saveUserThink(any(UserThinkForm.class));
+  }
+
+  @Test
+  @DisplayName("자신의 생각 가져오기 성공")
+  public void getUserThoughts_Success() throws Exception {
+    UserThinkDTO dto1 = new UserThinkDTO(18L, "이현준", "C5097400-1", "car", "good", false);
+    UserThinkDTO dto2 = new UserThinkDTO(20L, "이현준", "A5398300-1", "apple", "good", false);
+
+    Page<UserThinkDTO> page = new PageImpl<>(Arrays.asList(dto1, dto2), PageRequest.of(0, 10), 2);
+
+    when(userThinkService.isUserAuthenticated("이현준")).thenReturn(true);
+    when(userThinkService.getUserThoughts(eq("이현준"), any(Pageable.class))).thenReturn(page);
+
+    mockMvc.perform(get("/user-think/이현준?page=0&size=10")
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.totalElements").value(2))
+        .andExpect(jsonPath("$.content[0].id").value(18))
+        .andExpect(jsonPath("$.content[1].word").value("apple"));
+
+    verify(userThinkService, times(1)).isUserAuthenticated(eq("이현준"));
+    verify(userThinkService, times(1)).getUserThoughts(eq("이현준"), any(Pageable.class));
+  }
+
+  @Test
+  @DisplayName("자신의 생각 가져오기 실패")
+  public void getUserThoughts_Fail() throws Exception {
+    when(userThinkService.isUserAuthenticated("이현준")).thenReturn(false);
+
+    mockMvc.perform(get("/user-think/이현준?page=0&size=10")
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isForbidden());
+
+    verify(userThinkService, times(1)).isUserAuthenticated(eq("이현준"));
+    verify(userThinkService, never()).getUserThoughts(anyString(),
+        any(Pageable.class));
+  }
+
+  @Test
+  @DisplayName("다른 사람 생각 가져오기 성공")
+  public void getPublicThoughts_Success() throws Exception {
+    UserThinkDTO dto1 = new UserThinkDTO(14L, "이도현", "C5097400-1", "car", "apppppp", false);
+    UserThinkDTO dto2 = new UserThinkDTO(16L, "이도현", "C5097400-1", "car", "apppppp", false);
+    when(userThinkService.getPublicThoughts(anyString())).thenReturn(Arrays.asList(dto1, dto2));
+
+    mockMvc.perform(get("/user-think/public/이도현")
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].username").value("이도현"))
+        .andExpect(jsonPath("$[1].word").value("car"));
+
+    verify(userThinkService, times(1)).getPublicThoughts(eq("이도현"));
+  }
+
+  @Test
+  @DisplayName("다른 사람 생각 가져오기 실패")
+  public void getPublicThoughts_Fail() throws Exception {
+    when(userThinkService.getPublicThoughts(anyString())).thenThrow(
+        new ErrorResponse(SERVICE_EXCEPTION));
+
+    mockMvc.perform(get("/user-think/public/이도현")
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isInternalServerError());
+
+    verify(userThinkService, times(1)).getPublicThoughts(eq("이도현"));
+  }
+
+  @Test
+  @DisplayName("다른 사람 특정 단어의 생각 가져오기 성공")
+  public void getUserThinksByWord_Success() throws Exception {
+    UserThinkDTO dto1 = new UserThinkDTO(14L, "이도현", "C5097400-1", "car", "apppppp", false);
+    UserThinkDTO dto2 = new UserThinkDTO(16L, "이도현", "C5097400-1", "car", "apppppp", false);
+    when(userThinkService.getUserThinksByWord(anyString(), anyString())).thenReturn(
+        Arrays.asList(dto1, dto2));
+
+    mockMvc.perform(get("/user-think/word/이도현/C5097400-1")
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].wordId").value("C5097400-1"))
+        .andExpect(jsonPath("$[1].userThink").value("apppppp"));
+
+    verify(userThinkService, times(1)).getUserThinksByWord(eq("이도현"), eq("C5097400-1"));
+  }
+
+  @Test
+  @DisplayName("다른 사람 특정 단어의 생각 가져오기 실패")
+  public void getUserThinksByWord_Fail() throws Exception {
+    when(userThinkService.getUserThinksByWord(anyString(), anyString())).thenThrow(
+        new ErrorResponse(SERVICE_EXCEPTION));
+
+    mockMvc.perform(get("/user-think/word/이도현/C5097400-1")
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isInternalServerError());
+
+    verify(userThinkService, times(1)).getUserThinksByWord(eq("이도현"), eq("C5097400-1"));
+  }
+
+  @Test
+  @DisplayName("자신의 생각 삭제 성공")
+  public void deleteUserThink_Success() throws Exception {
+    mockMvc.perform(delete("/user-think/delete/이현준/18")
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isNoContent());
+
+    verify(userThinkService, times(1)).deleteUserThink(eq("이현준"), eq(18L));
+  }
+
+  @Test
+  @DisplayName("자신의 생각 삭제 실패")
+  public void deleteUserThink_Fail() throws Exception {
+    doThrow(new ErrorResponse(SERVICE_EXCEPTION)).when(userThinkService)
+        .deleteUserThink(anyString(), anyLong());
+
+    mockMvc.perform(delete("/user-think/delete/이현준/18")
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isInternalServerError());
+
+    verify(userThinkService, times(1)).deleteUserThink(eq("이현준"), eq(18L));
+  }
+}

--- a/src/test/java/com/github/Hyun_jun_Lee0811/dictionary/controller/WordBookControllerTest.java
+++ b/src/test/java/com/github/Hyun_jun_Lee0811/dictionary/controller/WordBookControllerTest.java
@@ -1,0 +1,88 @@
+package com.github.Hyun_jun_Lee0811.dictionary.controller;
+
+import com.github.Hyun_jun_Lee0811.dictionary.expection.ErrorResponse;
+import com.github.Hyun_jun_Lee0811.dictionary.model.dto.WordBookDTO;
+import com.github.Hyun_jun_Lee0811.dictionary.model.dto.WordBookEntryDTO;
+import com.github.Hyun_jun_Lee0811.dictionary.service.WordBookService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+
+import static com.github.Hyun_jun_Lee0811.dictionary.type.ErrorCode.*;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@EnableWebMvc
+public class WordBookControllerTest {
+
+  @Mock
+  private WordBookService wordBookService;
+
+  @InjectMocks
+  private WordBookController wordBookController;
+
+  private MockMvc mockMvc;
+
+  @BeforeEach
+  public void setUp() {
+    MockitoAnnotations.openMocks(this);
+    mockMvc = MockMvcBuilders.standaloneSetup(wordBookController).build();
+  }
+
+  @Test
+  @DisplayName("단어장 조회 성공")
+  public void getWordBookByUsernameAndWordId_Success() throws Exception {
+
+    WordBookDTO wordBookDTO = WordBookDTO.builder()
+        .word("apple")
+        .wordId("A5398300-2")
+        .createdAt(LocalDateTime.of(2024, 8, 14, 21, 35, 0))
+        .updatedAt(LocalDateTime.of(2024, 8, 14, 22, 45, 39))
+        .thinks(Arrays.asList(
+            WordBookEntryDTO.builder().id(122L).userThink("The apple is red.").build(),
+            WordBookEntryDTO.builder().id(123L).userThink("He ate the apple, stalk and all")
+                .build(),
+            WordBookEntryDTO.builder().id(126L).userThink("apple pie and custard").build(),
+            WordBookEntryDTO.builder().id(127L).userThink("Apples are very delicious.").build()
+        ))
+        .build();
+
+    given(wordBookService.getWordBookByUsernameAndWordId("이현준", "A5398300-2"))
+        .willReturn(Collections.singletonList(wordBookDTO));
+    given(wordBookService.isUserAuthenticated("이현준")).willReturn(true);
+
+    mockMvc.perform(get("/wordbook/search/이현준/A5398300-2"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$", hasSize(1)))
+        .andExpect(jsonPath("$[0].word", is("apple")))
+        .andExpect(jsonPath("$[0].wordId", is("A5398300-2")))
+        .andExpect(jsonPath("$[0].thinks[0].id", is(122)))
+        .andExpect(jsonPath("$[0].thinks[0].userThink", is("The apple is red.")));
+  }
+
+  @Test
+  @DisplayName("단어장 조회 실패")
+  public void getWordBookByUsernameAndWordId_Fail() throws Exception {
+
+    given(wordBookService.isUserAuthenticated("이현준")).willReturn(true);
+    given(wordBookService.getWordBookByUsernameAndWordId("이현준", "A5398300-2"))
+        .willThrow(new ErrorResponse(NO_USERTHINKS_FOUND_OR_ACCESS_DENIED));
+
+    mockMvc.perform(get("/wordbook/search/이현준/A5398300-2"))
+        .andExpect(status().isNotFound());
+  }
+}

--- a/src/test/java/com/github/Hyun_jun_Lee0811/dictionary/service/UserThinkServiceTest.java
+++ b/src/test/java/com/github/Hyun_jun_Lee0811/dictionary/service/UserThinkServiceTest.java
@@ -208,6 +208,45 @@ class UserThinkServiceTest {
   }
 
   @Test
+  @DisplayName("자신의 생각 변경 성공")
+  void changeUserThink_Success() {
+    User user = new User();
+    user.setUserId(1L);
+    user.setUsername("이현준");
+
+    UserThink think = new UserThink();
+    think.setId(21L);
+    think.setUserId(1L);
+    think.setWord("apple");
+    think.setUserThink("좋아");
+    think.setIsPrivate(false);
+
+    when(userThinkRepository.findById(21L)).thenReturn(Optional.of(think));
+    when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+    UserThinkForm form = new UserThinkForm();
+    form.setUsername("이현준");
+    form.setUserThink("변경");
+
+    assertDoesNotThrow(() -> userThinkService.changeUserThink(21L, form));
+
+    verify(userThinkRepository, times(1)).save(any(UserThink.class));
+  }
+
+  @Test
+  @DisplayName("자신의 생각 변경 실패 - 생각 없음")
+  void changeUserThink_Fail_NotFound() {
+    when(userThinkRepository.findById(21L)).thenReturn(Optional.empty());
+
+    UserThinkForm form = new UserThinkForm();
+    form.setUsername("이현준");
+
+    assertThrows(ErrorResponse.class, () -> userThinkService.changeUserThink(21L, form));
+
+    verify(userThinkRepository, never()).save(any(UserThink.class));
+  }
+
+  @Test
   @DisplayName("자신의 생각 삭제 성공")
   void deleteUserThink_Success() {
     User user = new User();

--- a/src/test/java/com/github/Hyun_jun_Lee0811/dictionary/service/UserThinkServiceTest.java
+++ b/src/test/java/com/github/Hyun_jun_Lee0811/dictionary/service/UserThinkServiceTest.java
@@ -1,0 +1,245 @@
+package com.github.Hyun_jun_Lee0811.dictionary.service;
+
+import com.github.Hyun_jun_Lee0811.dictionary.client.WordnikClient;
+import com.github.Hyun_jun_Lee0811.dictionary.expection.ErrorResponse;
+import com.github.Hyun_jun_Lee0811.dictionary.model.UserThinkForm;
+import com.github.Hyun_jun_Lee0811.dictionary.model.dto.UserThinkDTO;
+import com.github.Hyun_jun_Lee0811.dictionary.model.dto.WordDefinitionDto;
+import com.github.Hyun_jun_Lee0811.dictionary.model.entity.User;
+import com.github.Hyun_jun_Lee0811.dictionary.model.entity.UserThink;
+import com.github.Hyun_jun_Lee0811.dictionary.repository.UserThinkRepository;
+import com.github.Hyun_jun_Lee0811.dictionary.repository.UserRepository;
+import java.util.Collections;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+class UserThinkServiceTest {
+
+  @InjectMocks
+  private UserThinkService userThinkService;
+
+  @Mock
+  private UserThinkRepository userThinkRepository;
+  @Mock
+  private WordnikClient wordnikClient;
+  @Mock
+  private UserRepository userRepository;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+  }
+
+  @Test
+  @DisplayName("자신의 생각 저장 성공")
+  void saveUserThink_success() {
+    Authentication authentication = mock(Authentication.class);
+    when(authentication.getName()).thenReturn("이현준");
+    SecurityContext securityContext = mock(SecurityContext.class);
+    when(securityContext.getAuthentication()).thenReturn(authentication);
+    SecurityContextHolder.setContext(securityContext);
+
+    User user = new User();
+    user.setUserId(1L);
+    when(userRepository.findByUsername("이현준")).thenReturn(Optional.of(user));
+
+    WordDefinitionDto definition = new WordDefinitionDto();
+    definition.setId("C5097400-1");
+    when(wordnikClient.getDefinitions(anyString())).thenReturn(
+        Collections.singletonList(definition));
+
+    UserThinkForm userThinkForm = new UserThinkForm();
+    userThinkForm.setWord("apple");
+    userThinkForm.setUserThink("good");
+    userThinkForm.setIsPrivate(false);
+    userThinkForm.setUsername("이현준");
+
+    userThinkService.saveUserThink(userThinkForm);
+
+    verify(userThinkRepository, times(1)).save(any(UserThink.class));
+  }
+
+  @Test
+  @DisplayName("자신의 생각 저장 실패")
+  void saveUserThink_fail() {
+    when(mock(Authentication.class).getName()).thenReturn("이도현");
+    when(mock(SecurityContext.class).getAuthentication()).
+        thenReturn(mock(Authentication.class));
+    SecurityContextHolder.setContext(mock(SecurityContext.class));
+
+    UserThinkForm userThinkForm = new UserThinkForm();
+    userThinkForm.setWord("apple");
+    userThinkForm.setUserThink("good");
+    userThinkForm.setIsPrivate(false);
+    userThinkForm.setUsername("이현준");
+
+    assertThrows(ErrorResponse.class, () -> userThinkService.saveUserThink(userThinkForm));
+    verify(userThinkRepository, never()).save(any(UserThink.class));
+  }
+
+
+  @Test
+  @DisplayName("자신의 생각 가져오기 성공")
+  void getUserThoughts_Success() {
+    UserThink think = new UserThink();
+    think.setId(1L);
+    think.setUserId(1L);
+    think.setWord("apple");
+    think.setUserThink("good");
+    think.setIsPrivate(false);
+    think.setCreatedAt(LocalDateTime.now());
+
+    Pageable pageable = PageRequest.of(0, 10);
+    Page<UserThink> page = new PageImpl<>(List.of(think), pageable, 1);
+
+    User user = new User();
+    user.setUserId(1L);
+    user.setUsername("이현준");
+    user.setPassword("password");
+
+    when(userRepository.findByUsername("이현준")).thenReturn(Optional.of(user));
+    when(userThinkRepository.findByUserId(1L, pageable)).thenReturn(page);
+
+    Page<UserThinkDTO> result = userThinkService.getUserThoughts("이현준", pageable);
+
+    assertEquals(1, result.getTotalElements());
+    assertEquals("apple", result.getContent().get(0).getWord());
+  }
+
+  @Test
+  @DisplayName("자신의 생각 가져오기 실패")
+  void getUserThoughts_Fail() {
+    when(userRepository.findByUsername("이현준")).thenReturn(Optional.empty());
+
+    assertThrows(ErrorResponse.class, () ->
+        userThinkService.getUserThoughts("이현준", PageRequest.of(0, 10)));
+  }
+
+  @Test
+  @DisplayName("다른 사람 생각 가져오기 성공")
+  void getPublicThoughts_Success() {
+    UserThink think = new UserThink();
+    think.setId(1L);
+    think.setUserId(1L);
+    think.setWord("apple");
+    think.setUserThink("good");
+    think.setIsPrivate(false);
+
+    User user = new User();
+    user.setUserId(1L);
+    user.setUsername("이현준");
+    user.setPassword("password");
+
+    when(userRepository.findByUsername("이현준")).thenReturn(Optional.of(user));
+    when(userThinkRepository.findByUserIdAndIsPrivate(1L, false)).thenReturn(List.of(think));
+
+    List<UserThinkDTO> result = userThinkService.getPublicThoughts("이현준");
+
+    assertEquals(1, result.size());
+    assertEquals("good", result.get(0).getUserThink());
+  }
+
+  @Test
+  @DisplayName("다른 사람 생각 가져오기 실패")
+  void getPublicThoughts_Fail() {
+    when(userRepository.findByUsername("이현준")).thenReturn(Optional.empty());
+
+    assertThrows(ErrorResponse.class, () -> userThinkService.getPublicThoughts("이현준"));
+  }
+
+  @Test
+  @DisplayName("다른 사람 특정 단어의 생각 가져오기 성공")
+  void getUserThinksByWord_Success() {
+    UserThink think = new UserThink();
+    think.setId(1L);
+    think.setUserId(1L);
+    think.setWordId("C5097400-1");
+    think.setWord("이현준");
+    think.setUserThink("good");
+    think.setIsPrivate(false);
+
+    User user = new User();
+    user.setUserId(1L);
+    user.setUsername("이현준");
+    user.setPassword("password");
+
+    when(userRepository.findByUsername("이현준")).thenReturn(Optional.of(user));
+    when(userThinkRepository.findByUserIdAndWordId(1L, "C5097400-1")).thenReturn(List.of(think));
+
+    List<UserThinkDTO> result = userThinkService.getUserThinksByWord("이현준", "C5097400-1");
+
+    assertEquals(1, result.size());
+    assertEquals("good", result.get(0).getUserThink());
+  }
+
+  @Test
+  @DisplayName("다른 사람 특정 단어의 생각 가져오기 실패")
+  void getUserThinksByWord_Fail() {
+    User user = new User();
+    user.setUserId(1L);
+    user.setUsername("이현준");
+
+    when(userRepository.findByUsername("이현준")).thenReturn(Optional.of(user));
+    when(userThinkRepository.findByUserIdAndWordId(1L, "C5097400-1")).thenReturn(
+        Collections.emptyList());
+
+    assertThrows(ErrorResponse.class,
+        () -> userThinkService.getUserThinksByWord("이현준", "C5097400-1"));
+  }
+
+  @Test
+  @DisplayName("자신의 생각 삭제 성공")
+  void deleteUserThink_Success() {
+    User user = new User();
+    user.setUserId(1L);
+    user.setUsername("이현준");
+    user.setPassword("password");
+
+    UserThink think = new UserThink();
+    think.setId(1L);
+    think.setUserId(1L);
+    think.setWord("apple");
+    think.setUserThink("good");
+    think.setIsPrivate(false);
+
+    when(userRepository.findByUsername("이현준")).thenReturn(Optional.of(user));
+    when(userThinkRepository.findById(1L)).thenReturn(Optional.of(think));
+
+    UserThinkService spyService = spy(userThinkService);
+    doReturn(true).when(spyService).isUserAuthenticated("이현준");
+
+    assertDoesNotThrow(() -> spyService.deleteUserThink("이현준", 1L));
+
+    verify(userThinkRepository, times(1)).delete(any(UserThink.class));
+  }
+
+  @Test
+  @DisplayName("자신의 생각 삭제 실패")
+  void deleteUserThink_Fail() {
+    when(userThinkRepository.findById(1L)).thenReturn(Optional.empty());
+
+    assertThrows(ErrorResponse.class, () -> userThinkService.deleteUserThink("이현준", 1L));
+
+    verify(userThinkRepository, never()).delete(any(UserThink.class));
+  }
+}

--- a/src/test/java/com/github/Hyun_jun_Lee0811/dictionary/service/UserThinkServiceTest.java
+++ b/src/test/java/com/github/Hyun_jun_Lee0811/dictionary/service/UserThinkServiceTest.java
@@ -9,6 +9,7 @@ import com.github.Hyun_jun_Lee0811.dictionary.model.entity.User;
 import com.github.Hyun_jun_Lee0811.dictionary.model.entity.UserThink;
 import com.github.Hyun_jun_Lee0811.dictionary.repository.UserThinkRepository;
 import com.github.Hyun_jun_Lee0811.dictionary.repository.UserRepository;
+import com.github.Hyun_jun_Lee0811.dictionary.security.JwtAuthenticationFilter;
 import java.util.Collections;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -43,6 +44,8 @@ class UserThinkServiceTest {
   @Mock
   private WordnikClient wordnikClient;
   @Mock
+  private JwtAuthenticationFilter jwtAuthenticationFilter;
+  @Mock
   private UserRepository userRepository;
 
   @BeforeEach
@@ -71,6 +74,7 @@ class UserThinkServiceTest {
     when(wordnikClient.getDefinitions("apple")).thenReturn(
         Collections.singletonList(wordDefinitionDto));
     when(userThinkRepository.countByUserId(1L)).thenReturn(0L);
+    when(jwtAuthenticationFilter.isUserAuthenticated("이현준")).thenReturn(true); // 추가
 
     UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
         "이현준", null, Collections.emptyList());
@@ -265,11 +269,9 @@ class UserThinkServiceTest {
 
     when(userRepository.findByUsername("이현준")).thenReturn(Optional.of(user));
     when(userThinkRepository.findById(1L)).thenReturn(Optional.of(think));
+    when(jwtAuthenticationFilter.isUserAuthenticated("이현준")).thenReturn(true);
 
-    UserThinkService spyService = spy(userThinkService);
-    doReturn(true).when(spyService).isUserAuthenticated("이현준");
-
-    assertDoesNotThrow(() -> spyService.deleteUserThink("이현준", 1L));
+    assertDoesNotThrow(() -> userThinkService.deleteUserThink("이현준", 1L));
 
     verify(userThinkRepository, times(1)).delete(any(UserThink.class));
   }

--- a/src/test/java/com/github/Hyun_jun_Lee0811/dictionary/service/UserThinkServiceTest.java
+++ b/src/test/java/com/github/Hyun_jun_Lee0811/dictionary/service/UserThinkServiceTest.java
@@ -48,6 +48,7 @@ class UserThinkServiceTest {
   @BeforeEach
   void setUp() {
     MockitoAnnotations.openMocks(this);
+    SecurityContextHolder.clearContext();
   }
 
   @Test

--- a/src/test/java/com/github/Hyun_jun_Lee0811/dictionary/service/UserThinkServiceTest.java
+++ b/src/test/java/com/github/Hyun_jun_Lee0811/dictionary/service/UserThinkServiceTest.java
@@ -24,13 +24,13 @@ import org.springframework.data.domain.Pageable;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 class UserThinkServiceTest {
@@ -53,26 +53,27 @@ class UserThinkServiceTest {
   @Test
   @DisplayName("자신의 생각 저장 성공")
   void saveUserThink_success() {
-    Authentication authentication = mock(Authentication.class);
-    when(authentication.getName()).thenReturn("이현준");
-    SecurityContext securityContext = mock(SecurityContext.class);
-    when(securityContext.getAuthentication()).thenReturn(authentication);
-    SecurityContextHolder.setContext(securityContext);
-
-    User user = new User();
-    user.setUserId(1L);
-    when(userRepository.findByUsername("이현준")).thenReturn(Optional.of(user));
-
-    WordDefinitionDto definition = new WordDefinitionDto();
-    definition.setId("C5097400-1");
-    when(wordnikClient.getDefinitions(anyString())).thenReturn(
-        Collections.singletonList(definition));
-
     UserThinkForm userThinkForm = new UserThinkForm();
+    userThinkForm.setUsername("이현준");
     userThinkForm.setWord("apple");
     userThinkForm.setUserThink("good");
     userThinkForm.setIsPrivate(false);
-    userThinkForm.setUsername("이현준");
+
+    User user = new User();
+    user.setUserId(1L);
+    user.setUsername("이현준");
+
+    WordDefinitionDto wordDefinitionDto = new WordDefinitionDto();
+    wordDefinitionDto.setId("A5398300-1");
+
+    when(userRepository.findByUsername("이현준")).thenReturn(Optional.of(user));
+    when(wordnikClient.getDefinitions("apple")).thenReturn(
+        Collections.singletonList(wordDefinitionDto));
+    when(userThinkRepository.countByUserId(1L)).thenReturn(0L);
+
+    UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+        "이현준", null, Collections.emptyList());
+    SecurityContextHolder.getContext().setAuthentication(authentication);
 
     userThinkService.saveUserThink(userThinkForm);
 

--- a/src/test/java/com/github/Hyun_jun_Lee0811/dictionary/service/WordBookServiceTest.java
+++ b/src/test/java/com/github/Hyun_jun_Lee0811/dictionary/service/WordBookServiceTest.java
@@ -1,0 +1,94 @@
+package com.github.Hyun_jun_Lee0811.dictionary.service;
+
+import com.github.Hyun_jun_Lee0811.dictionary.expection.ErrorResponse;
+import com.github.Hyun_jun_Lee0811.dictionary.model.dto.WordBookDTO;
+import com.github.Hyun_jun_Lee0811.dictionary.model.dto.WordBookEntryDTO;
+import com.github.Hyun_jun_Lee0811.dictionary.model.entity.User;
+import com.github.Hyun_jun_Lee0811.dictionary.model.entity.UserThink;
+import com.github.Hyun_jun_Lee0811.dictionary.repository.UserThinkRepository;
+import com.github.Hyun_jun_Lee0811.dictionary.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.time.LocalDateTime;
+import java.util.*;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+public class WordBookServiceTest {
+
+  @Mock
+  private UserThinkRepository userThinkRepository;
+
+  @Mock
+  private UserRepository userRepository;
+
+  @InjectMocks
+  private WordBookService wordBookService;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+    SecurityContextHolder.clearContext();
+  }
+
+  @Test
+  public void getWordBookByUsernameAndWordId_Success() {
+
+    User user = new User();
+    user.setUserId(1L);
+
+    UserThink userThink = new UserThink();
+    userThink.setWord("hello");
+    userThink.setWordId("A5398300-1");
+    userThink.setUserId(1L);
+    userThink.setCreatedAt(LocalDateTime.now());
+    userThink.setUpdatedAt(null);
+    userThink.setId(1L);
+    userThink.setUserThink("test think");
+    userThink.setIsPrivate(false);
+
+    when(userRepository.findByUsername("이현준")).thenReturn(Optional.of(user));
+    when(userThinkRepository.findByUserIdAndWordIdAndIsPrivate(1L, "A5398300-1", false))
+        .thenReturn(Collections.singletonList(userThink));
+    when(mock(Authentication.class).isAuthenticated()).thenReturn(true);
+    when(mock(Authentication.class).getName()).thenReturn("이현준");
+    when(mock(SecurityContext.class).getAuthentication()).thenReturn(mock(Authentication.class));
+
+    SecurityContextHolder.setContext(mock(SecurityContext.class));
+
+    List<WordBookDTO> result = wordBookService.getWordBookByUsernameAndWordId("이현준", "A5398300-1");
+    WordBookDTO wordBookDTO = result.get(0);
+    WordBookEntryDTO entryDTO = wordBookDTO.getThinks().get(0);
+
+    assertNotNull(result);
+    assertEquals(1, result.size());
+    assertEquals("hello", wordBookDTO.getWord());
+    assertEquals("A5398300-1", wordBookDTO.getWordId());
+    assertEquals(1, wordBookDTO.getThinks().size());
+    assertEquals(1L, entryDTO.getId());
+    assertEquals("test think", entryDTO.getUserThink());
+  }
+
+  @Test
+  void getWordBookByUsernameAndWordId_Fail() {
+
+    User user = new User();
+    user.setUserId(1L);
+
+    when(userRepository.findByUsername("이현준")).thenReturn(Optional.of(user));
+
+    when(userThinkRepository.findByUserIdAndWordIdAndIsPrivate(1L, "A5398300-1", false))
+        .thenReturn(Collections.emptyList());
+
+    assertThrows(ErrorResponse.class,
+        () -> wordBookService.getWordBookByUsernameAndWordId("이현준", "A5398300-1"));
+  }
+}

--- a/src/test/java/com/github/Hyun_jun_Lee0811/dictionary/service/WordBookServiceTest.java
+++ b/src/test/java/com/github/Hyun_jun_Lee0811/dictionary/service/WordBookServiceTest.java
@@ -8,6 +8,7 @@ import com.github.Hyun_jun_Lee0811.dictionary.model.entity.UserThink;
 import com.github.Hyun_jun_Lee0811.dictionary.repository.UserThinkRepository;
 import com.github.Hyun_jun_Lee0811.dictionary.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -40,6 +41,7 @@ public class WordBookServiceTest {
   }
 
   @Test
+  @DisplayName("단어장 조회 성공")
   public void getWordBookByUsernameAndWordId_Success() {
 
     User user = new User();
@@ -78,6 +80,7 @@ public class WordBookServiceTest {
   }
 
   @Test
+  @DisplayName("단어장 조회 실패")
   void getWordBookByUsernameAndWordId_Fail() {
 
     User user = new User();


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 사용자의 회원가입, 로그인, 비밀번호와 이름 변경 그리고 사용자 계정 삭제 기능이 구현되어 있었습니다.
- 사용자가 단어를 검색하고, 단어에 대한 정의, 예시, 관련 단어, 어원 등의 정보를 제공하는 기능이 구현되어 있었습니다.

**TO-BE**
- 단어장 기능이 추가되어, 사용자가 특정 단어에 대한 자신의 생각을 저장하고 관리할 수 있도록 구현되었습니다.
- 사용자는 자신의 생각을 비공개 또는 공개로 설정할 수 있으며, 자신의 생각을 저장, 조회, 수정, 삭제할 수 있는 API를 추가하였습니다.
- 다른 사용자의 공개된 생각을 조회할 수 있는 기능을 구현하여, 다른 사람들이 특정 단어에 대해 어떻게 생각하는지 확인할 수 있도록 하였습니다.
- 생각을 저장 그리고 조회하면서 일아나는 에러를 처리하기 위한 ErrorCode를 구현하였고, 에러 핸들링의 응답과 API 응답 모두 ErrorResponse 클래스를 통해 처리하도록 하였습니다.
- MariaDB 연동을 통해 사용자와 단어장과 사용자가 작성 Think 데이터를 영구적으로 저장 및 관리할 수 있게 하였습니다.

### 테스트
- [x] 테스트 코드
- 단어장 조회 성공: 사용자가 특정 단어에 대한 자신의 생각을 정상적으로 조회할 수 있는지 확인하는 테스트하였습니다.
- 단어장 조회 실패: 잘못된 사용자 이름이나 단어 ID로 조회 시도가 실패하는지 확인하는 테스트하였습니다.
- 자신의 생각 저장 성공: 사용자가 특정 단어에 대한 생각을 정상적으로 저장할 수 있는지 확인하는 테스트추가하였습니다.
- 자신의 생각 저장 실패: 저장 중 오류가 발생했을 때 실패하는지 확인하는 테스트를 하였습니다.
- 자신의 생각 가져오기 성공: 사용자가 정상적으로 자신이 작성한 생각을 조회할 수 있는지 테스트하였습니다.
- 자신의 생각 가져오기 실패: 사용자가 존재하지 않을 때 실패하는지 확인하는 테스트하였습니다.
- 다른 사람 생각 조회 성공: 다른 사용자의 공개된 생각을 정상적으로 조회할 수 있는지 확인하는 테스트하였습니다.
- 다른 사람 생각 조회 실패: 존재하지 않는 사용자의 생각을 조회하려 할 때 실패하는지 확인하는 테스트하였습니다.
- 다른 사람 특정 단어의 생각 가져오기 성공: 다른 사용자의 공개된 생각 중 특정 단어를 조회할 수 있는지 테스트하였습니다.
- 다른 사람 특정 단어의 생각 가져오기 실패: 다른 사용자의 공개된 생각 중 특정 단어를 생각이 존재하지 않을 때의 실패 상황을 테스트하였습니다.
- 자신의 생각 변경 성공: 사용자가 자신의 생각을 정상적으로 변경할 수 있는지 확인하는 테스트하였습니다.
- 자신의 생각 변경 실패: 존재하지 않는 생각을 변경하려 할 때 실패하는지 확인하는 테스트하였습니다.
- 자신의 생각 삭제 성공: 사용자가 자신의 생각을 정상적으로 삭제할 수 있는지 확인하는 테스트하였습니다.
- 자신의 생각 삭제 실패: 삭제 중 오류가 발생했을 때 실패하는지 확인하는 테스트하였습니다.

- [x] API 테스트 
- 단어장 조회 API: 사용자가 특정 단어에 대한 단어장을 성공적으로 조회하거나, 조회 시 오류가 발생했을 때 에러 처리가 되는지 테스트하였습니다.
- 자신의 생각 저장 API: 사용자가 자신의 생각을 성공적으로 저장하거나, 저장 실패 시 에러 처리가 되는지 테스트하였습니다.
- 자신의 생각 가져오는 API: 사용자가 자신의 생각을 성공적으로 조회하거나, 인증되지 않았을 때 오류 처리가 되는지 테스트하였습니다.
- 다른 사람의 공개된 생각 조회 API: 다른 사용자의 공개된 생각을 성공적으로 조회하거나, 조회 실패 시 적절한 에러 처리가 되는지 테스트하였습니다.
- 다른 사람의 특정 단어에 대한 생각 조회 API: 다른 사용자가 특정 단어에 대해 남긴 생각을 성공적으로 조회하거나, 조회 실패 시 오류 처리가 되는지 테스트하였습니다.
- 자신의 생각 수정 API: 사용자가 자신의 생각을 성공적으로 수정하거나, 수정할 생각이 존재하지 않을 때 오류 처리가 되는지 테스트하였습니다.
- 자신의 생각 삭제 API: 사용자가 자신의 생각을 성공적으로 삭제하거나, 삭제 시 오류가 발생했을 때 에러 처리가 되는지 테스트하였습니다.