### PR TITLE
feat: 단어장 검색 시 방문자 수 카운트 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.mariadb.jdbc:mariadb-java-client:3.3.3'
 
     compileOnly 'org.projectlombok:lombok'
@@ -44,11 +45,8 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 
-    // Elasticsearch Java API Client
     implementation 'co.elastic.clients:elasticsearch-java:8.13.4'
-    // Jackson Databind
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.0'
-    // Apache HttpComponents
     implementation 'org.apache.httpcomponents:httpclient:4.5.13'
 
     implementation 'org.apache.commons:commons-collections4:4.4'

--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/DictionaryApplication.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/DictionaryApplication.java
@@ -2,12 +2,15 @@ package com.github.Hyun_jun_Lee0811.dictionary;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableCaching
+@EnableScheduling
 @SpringBootApplication
 public class DictionaryApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(DictionaryApplication.class, args);
-	}
-
+  public static void main(String[] args) {
+    SpringApplication.run(DictionaryApplication.class, args);
+  }
 }

--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/config/RedisConfig.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/config/RedisConfig.java
@@ -1,0 +1,37 @@
+package com.github.Hyun_jun_Lee0811.dictionary.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericToStringSerializer;
+
+@Configuration
+public class RedisConfig {
+
+  @Value("${spring.data.redis.host}")
+  private String host;
+
+  @Value("${spring.data.redis.port}")
+  private int port;
+
+  @Bean
+  public RedisTemplate<String, Long> redisTemplate() {
+    RedisTemplate<String, Long> template = new RedisTemplate<>();
+    template.setConnectionFactory(redisConnectionFactory());
+    // Long 타입의 값을 문자열로 변환하여 Redis에 저장하고 읽어올 때 사용합니다.
+    template.setHashValueSerializer(new GenericToStringSerializer<>(Long.class));
+    template.setValueSerializer(new GenericToStringSerializer<>(Long.class));
+    return template;
+  }
+
+  @Bean
+  public LettuceConnectionFactory redisConnectionFactory() {
+    RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
+    config.setHostName(host);
+    config.setPort(port);
+    return new LettuceConnectionFactory(config);
+  }
+}

--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/model/entity/VisitorSummary.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/model/entity/VisitorSummary.java
@@ -1,0 +1,30 @@
+package com.github.Hyun_jun_Lee0811.dictionary.model.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "visitor_summary", indexes =
+    {@Index(name = "idx_user_id", columnList = "USER_ID")})
+public class VisitorSummary {
+
+  @Id
+  @Column(name = "USER_ID", nullable = false)
+  private Long userId;
+
+  @Column(name = "TOTAL_COUNT", nullable = false)
+  private Long totalCount;
+}

--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/repository/UserThinkRepository.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/repository/UserThinkRepository.java
@@ -5,7 +5,9 @@ import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface UserThinkRepository extends JpaRepository<UserThink, Long> {
 
   List<UserThink> findByUserIdAndIsPrivate(Long userId, Boolean isPrivate);

--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/repository/VisitorSummaryRepository.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/repository/VisitorSummaryRepository.java
@@ -1,0 +1,12 @@
+package com.github.Hyun_jun_Lee0811.dictionary.repository;
+
+import com.github.Hyun_jun_Lee0811.dictionary.model.entity.VisitorSummary;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface VisitorSummaryRepository extends JpaRepository<VisitorSummary, Long> {
+
+  Optional<VisitorSummary> findByUserId(Long userId);
+}

--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/repository/WordBookRepository.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/repository/WordBookRepository.java
@@ -3,7 +3,9 @@ package com.github.Hyun_jun_Lee0811.dictionary.repository;
 import com.github.Hyun_jun_Lee0811.dictionary.model.entity.WordBook;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface WordBookRepository extends JpaRepository<WordBook, Long> {
 
   Optional<WordBook> findByUserIdAndWord(Long userId, String word);

--- a/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/service/WordBookService.java
+++ b/src/main/java/com/github/Hyun_jun_Lee0811/dictionary/service/WordBookService.java
@@ -5,12 +5,16 @@ import com.github.Hyun_jun_Lee0811.dictionary.model.dto.WordBookEntryDTO;
 import com.github.Hyun_jun_Lee0811.dictionary.model.dto.WordBookDTO;
 import com.github.Hyun_jun_Lee0811.dictionary.model.entity.User;
 import com.github.Hyun_jun_Lee0811.dictionary.model.entity.UserThink;
+import com.github.Hyun_jun_Lee0811.dictionary.model.entity.VisitorSummary;
 import com.github.Hyun_jun_Lee0811.dictionary.repository.UserThinkRepository;
 import com.github.Hyun_jun_Lee0811.dictionary.repository.UserRepository;
+import com.github.Hyun_jun_Lee0811.dictionary.repository.VisitorSummaryRepository;
 import com.github.Hyun_jun_Lee0811.dictionary.type.ErrorCode;
 import java.time.LocalDateTime;
 import java.util.*;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
@@ -21,9 +25,16 @@ public class WordBookService {
 
   private final UserThinkRepository userThinkRepository;
   private final UserRepository userRepository;
+  private final VisitorSummaryRepository visitorSummaryRepository;
+  private final RedisTemplate<String, Long> redisTemplate;
+
+  public void incrementVisitorCount(String username) {
+    redisTemplate.opsForHash()
+        .increment("visitor_counts", getUserIdByUsername(username).toString(), 1);
+  }
 
   public List<WordBookDTO> getWordBookByUsernameAndWordId(String username, String wordId) {
-
+    incrementVisitorCount(username);
     if (getFilteredUserThinks(getUserIdByUsername(username), wordId).isEmpty()) {
       throw new ErrorResponse(ErrorCode.NO_USERTHINKS_FOUND_OR_ACCESS_DENIED);
     }
@@ -38,6 +49,22 @@ public class WordBookService {
     }
 
     return username.equals(authentication.getName());
+  }
+
+  @Scheduled(cron = "0 0 0 * * *")
+  private void syncDailyVisitorCounts() {
+    for (Map.Entry<Object, Object> entry :
+        redisTemplate.opsForHash().entries("visitor_counts").entrySet()) {
+
+      VisitorSummary visitorSummary = visitorSummaryRepository.findByUserId(
+              Long.parseLong((String) entry.getKey()))
+          .orElse(new VisitorSummary(Long.parseLong((String) entry.getKey()), 0L));
+
+      visitorSummary.setTotalCount(visitorSummary.getTotalCount() + (Long) entry.getValue());
+      visitorSummaryRepository.save(visitorSummary);
+    }
+
+    redisTemplate.delete("visitor_counts");
   }
 
   private List<UserThink> getFilteredUserThinks(Long userId, String wordId) {

--- a/src/test/java/com/github/Hyun_jun_Lee0811/dictionary/service/WordBookServiceTest.java
+++ b/src/test/java/com/github/Hyun_jun_Lee0811/dictionary/service/WordBookServiceTest.java
@@ -16,6 +16,8 @@ import org.mockito.MockitoAnnotations;
 
 import java.time.LocalDateTime;
 import java.util.*;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -31,6 +33,12 @@ public class WordBookServiceTest {
   @Mock
   private UserRepository userRepository;
 
+  @Mock
+  private RedisTemplate<String, Long> redisTemplate;
+
+  @Mock
+  private HashOperations<String, Object, Object> hashOperations;
+
   @InjectMocks
   private WordBookService wordBookService;
 
@@ -38,6 +46,7 @@ public class WordBookServiceTest {
   void setUp() {
     MockitoAnnotations.openMocks(this);
     SecurityContextHolder.clearContext();
+    when(redisTemplate.opsForHash()).thenReturn(hashOperations);
   }
 
   @Test
@@ -63,6 +72,7 @@ public class WordBookServiceTest {
     when(mock(Authentication.class).isAuthenticated()).thenReturn(true);
     when(mock(Authentication.class).getName()).thenReturn("이현준");
     when(mock(SecurityContext.class).getAuthentication()).thenReturn(mock(Authentication.class));
+    when(hashOperations.increment(anyString(), anyString(), anyLong())).thenReturn(1L);
 
     SecurityContextHolder.setContext(mock(SecurityContext.class));
 
@@ -90,6 +100,7 @@ public class WordBookServiceTest {
 
     when(userThinkRepository.findByUserIdAndWordIdAndIsPrivate(1L, "A5398300-1", false))
         .thenReturn(Collections.emptyList());
+    when(hashOperations.increment(anyString(), anyString(), anyLong())).thenReturn(1L);
 
     assertThrows(ErrorResponse.class,
         () -> wordBookService.getWordBookByUsernameAndWordId("이현준", "A5398300-1"));


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 단어장 검색 시 방문자 수 카운트를 하도록 추가하였습니다.
  - WordBookService의 getWordBookByUsernameAndWordId 메서드에 방문자 수를 증가시키는 로직이 추가되었습니다.
  - 사용자가 단어장을 조회할 때마다 Redis를 사용하여 방문자 수를 카운트합니다.
  
**TO-BE**
- 매일 자정에 방문자 수를 데이터베이스에 동기화하는 로직이 추가되었습니다. Redis에서 관리되던 방문자 수를 데이터베이스에 저장하고, Redis는 초기화됩니다.

### 테스트
- [x] 테스트 코드
- 기존에 있던 단어장 테스트 코드에 RedisTemplate과 HashOperations를 Mock하여 테스트하였습니다.